### PR TITLE
syntax fix for plausible_data_gen.py

### DIFF
--- a/plausible_data_gen.py
+++ b/plausible_data_gen.py
@@ -497,7 +497,7 @@ def main():
     else:
         print("Either 'values' or 'gurl' should be specified. See usage.")
         sys.exit()
-    replace_values(simulated_data, values_table)
+        replace_values(simulated_data, values_table)
     if not args.name:
         name = os.path.basename(os.path.split(args.path)[0])
     else:


### PR DESCRIPTION
There is a missing tab that prevents the replace_values function from being called properly