### PR TITLE
category data_file now adds data_file property ref

### DIFF
--- a/src/gen3schemadev/converter.py
+++ b/src/gen3schemadev/converter.py
@@ -525,8 +525,8 @@ def construct_props(node_name: str, data: DataSourceProtocol) -> dict:
     props = get_properties(node_name, data)
     props = strip_required_field(props)
     node_data = get_node_data(node_name, data)
-    category =  node_data.category
-    
+    category = node_data.category
+
     # Flatten property dicts into a single dict
     props_dict = {}
     # add ubiquitous property ref
@@ -536,16 +536,17 @@ def construct_props(node_name: str, data: DataSourceProtocol) -> dict:
             prop = format_enum(prop)
             prop = format_datetime(prop)
             props_dict.update(prop)
-    
+
     # Add link properties
     for link in links:
         link_prop = create_link_prop(link['parent'], link['multiplicity'])
         props_dict.update(link_prop)
-    
+
     # if it's an Enum, add the enum values
     if category == "data_file":
         props_dict['core_metadata_collections'] = {"$ref": "_definitions.yaml#/to_one"}
-    
+        props_dict['$ref'] = "_definitions.yaml#/data_file_properties"
+
     return props_dict
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -447,10 +447,26 @@ def test_format_enum_missing_description():
 def test_construct_prop_lipidomics_file(fixture_input_yaml_pass):
     result = construct_props("lipidomics_file", fixture_input_yaml_pass)
     expected = {
-        "$ref": "_definitions.yaml#/ubiquitous_properties",
+        "$ref": "_definitions.yaml#/data_file_properties",
         "samples": {"$ref": "_definitions.yaml#/to_many"},
         "assays": {"$ref": "_definitions.yaml#/to_many"},
         "core_metadata_collections": {"$ref": "_definitions.yaml#/to_one"},
+        
+    }
+    assert result == expected
+
+def test_construct_prop_project(fixture_input_yaml_pass):
+    result = construct_props("project", fixture_input_yaml_pass)
+    expected = {
+        "$ref": "_definitions.yaml#/ubiquitous_properties",
+        "project_id": {
+            "type": "string",
+            "description": "Synthetic_Dataset_1"
+        },
+        "description": {
+            "type": "string",
+            "description": "Project containing synthetic data"
+        }
     }
     assert result == expected
 
@@ -567,7 +583,7 @@ def fixture_expected_output_lipid():
             ]
         }],
         'properties': {
-            '$ref': '_definitions.yaml#/ubiquitous_properties',
+            '$ref': '_definitions.yaml#/data_file_properties',
             'samples': {'$ref': '_definitions.yaml#/to_many'},
             'assays': {'$ref': '_definitions.yaml#/to_many'},
             'core_metadata_collections': {'$ref': '_definitions.yaml#/to_one'}


### PR DESCRIPTION
- Adjusted the construct_props function to set the $ref for data_file properties to "_definitions.yaml#/data_file_properties".
- Updated unit tests to reflect the new $ref value for lipidomics files and added a test for project properties.