### PR TITLE
Add 'init' command to CLI for schema initialization and update quicks…

### DIFF
--- a/docs/gen3schemadev/quickstart.md
+++ b/docs/gen3schemadev/quickstart.md
@@ -14,13 +14,15 @@
 - Learn how to create one [here](first_dictionary.md).
 - You can also create a template starting file with the command below.
 ```bash
-gen3schemadev template -o input_example.yml
+gen3schemadev init
+# alternatively you can define the template file name
+gen3schemadev init -o input_example.yaml
 ```
 
 ## 3. Generate Gen3 Schemas
 - Will convert the input_yaml to a folder of gen3 schemas.
 ```bash
-gen3schemadev generate -i tests/input_example.yml -o gen3_data_dictionary/
+gen3schemadev generate -i input_example.yaml -o gen3_data_dictionary/
 ```
 
 ### 3.1 Further Gen3 Yaml Configuration (optional)
@@ -31,7 +33,7 @@ gen3schemadev generate -i tests/input_example.yml -o gen3_data_dictionary/
 
 ## 4. Validate schema
 - After you are happy with the folder of gen3 schemas, you can validate them using the `gen3schemadev validate` command.
-- This will do two things, first it will do a validation against the [gen3 metaschema](../../src/gen3schemadev/schema/schema_templates/gen3_metaschema.yml) and secondly it will do business rule validation based on the logic in the [`rule_validator.py` module](../../src/gen3schemadev/validators/rule_validator.py) 
+- This will do two things, first it will do a validation against the [gen3 metaschema](../../src/gen3schemadev/schema/schema_templates/gen3_metaschema.yaml) and secondly it will do business rule validation based on the logic in the [`rule_validator.py` module](../../src/gen3schemadev/validators/rule_validator.py) 
 ```bash
 gen3schemadev validate -y gen3_data_dictionary
 ```

--- a/src/gen3schemadev/cli.py
+++ b/src/gen3schemadev/cli.py
@@ -108,7 +108,7 @@ def main():
         action="store_true",
         help="Disables the exclusion of specific schema from the validation"
     )
-    
+
     # Create 'visualise' subcomand
     visualise_parser = subparsers.add_parser(
         "visualise",
@@ -125,6 +125,22 @@ def main():
         help="Set logging level to DEBUG"
     )
 
+    # Create 'init' subcommand
+    init_parser = subparsers.add_parser(
+        "init",
+        help="Initialize gen3schemadev"
+    )
+    init_parser.add_argument(
+        "-o", "--output",
+        required=False,
+        help="Output directory"
+    )
+    init_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Set logging level to DEBUG"
+    )
+    
     args = parser.parse_args()
     
     # Handle case where no command is provided
@@ -237,6 +253,51 @@ def main():
     elif args.command == "visualise":
         print(f"Visualising schema from file: {args.input}")
         visualise_with_docker(args.input)
+    
+    
+    elif args.command == "init":
+        init_yaml = {
+            "version": "0.1.0",
+            "url": "https://link-to-data-portal",
+            "nodes": [
+                {
+                    "name": "subject",
+                    "description": "The subject or patient",
+                    "category": "clinical",
+                    "properties": [
+                        {
+                            "name": "subject_id",
+                            "type": "string",
+                            "description": "A deidentified identifier for the subject",
+                            "required": True
+                        }
+                    ]
+                },
+                {
+                    "name": "sample",
+                    "description": "Info about sample",
+                    "category": "clinical",
+                    "properties": [
+                        {
+                            "name": "sample_id",
+                            "type": "string",
+                            "description": "Sample ID (string)",
+                            "required": True
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "parent": "subject",
+                    "multiplicity": "one_to_many",
+                    "child": "sample"
+                }
+            ]
+        }
+
+        output_path = args.output or "input_example.yaml"
+        write_yaml(init_yaml, output_path)
 
 if __name__ == "__main__":
     main()

--- a/src/gen3schemadev/utils.py
+++ b/src/gen3schemadev/utils.py
@@ -41,9 +41,11 @@ def write_yaml(data, file_path):
     Logs success or error messages.
     """
     try:
-        create_dir_if_not_exists(file_path)
+        dir_path = os.path.dirname(file_path)
+        if dir_path:
+            create_dir_if_not_exists(file_path)
         with open(file_path, 'w') as f:
-            yaml.safe_dump(data, f, sort_keys=False)
+            yaml.safe_dump(data, f, sort_keys=False, indent=2)
             logger.info(f"Successfully wrote YAML file: {file_path}")
     except Exception as e:
         logger.error(f"Failed to write YAML file {file_path}: {e}")


### PR DESCRIPTION
…tart documentation

- Introduced a new 'init' subcommand in the CLI to initialize Gen3 schemas with a default YAML structure.
- Updated the quickstart guide to reflect changes in command usage, including the new 'init' command and the updated output file format.
- Enhanced the YAML writing function to ensure directory creation if needed and improved formatting for better readability.