### PR TITLE
Implement multiplicity flipping in link conversion

### DIFF
--- a/src/gen3schemadev/converter.py
+++ b/src/gen3schemadev/converter.py
@@ -196,6 +196,25 @@ def create_core_metadata_link(child_name: str, required: bool = False) -> dict:
     return link_obj.to_dict()
 
 
+def flip_multiplicity(multiplicity: str) -> str:
+    """
+    Flip the multiplicity of a link.
+
+    Args:
+        multiplicity: The current multiplicity of the link.
+
+    Returns:
+        The flipped multiplicity.
+    """
+    if multiplicity == "one_to_one" or multiplicity == "many_to_many":
+        return multiplicity
+    elif multiplicity == "one_to_many":
+        return "many_to_one"
+    elif multiplicity == "many_to_one":
+        return "one_to_many"
+    else:
+        raise ValueError(f"Invalid multiplicity: {multiplicity}")
+
 def convert_node_links(links: list[dict], required: bool = True) -> list[dict]:
     """
     Convert a list of link dictionaries into the Gen3 schema 'links' format.
@@ -214,7 +233,7 @@ def convert_node_links(links: list[dict], required: bool = True) -> list[dict]:
             backref=link_suffix(link['child']),
             label="part_of",
             target_type=link['parent'],
-            multiplicity=link['multiplicity'],
+            multiplicity=flip_multiplicity(link['multiplicity']),
             required=required
         )
         link_list.append(link_obj.to_dict())
@@ -539,7 +558,7 @@ def construct_props(node_name: str, data: DataSourceProtocol) -> dict:
 
     # Add link properties
     for link in links:
-        link_prop = create_link_prop(link['parent'], link['multiplicity'])
+        link_prop = create_link_prop(link['parent'], flip_multiplicity(link['multiplicity']))
         props_dict.update(link_prop)
 
     # if it's an Enum, add the enum values

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -75,7 +75,7 @@ def test_convert_node_links():
     assert link0["name"] == "samples"
     assert link0["backref"] == "lipidomics_files"
     assert link0["target_type"] == "sample"
-    assert link0["multiplicity"] == "many_to_one"
+    assert link0["multiplicity"] == "one_to_many"
     assert link0["required"] is True
     assert "label" in link0 and link0["label"] is 'part_of'
 
@@ -84,7 +84,7 @@ def test_convert_node_links():
     assert link1["name"] == "projects"
     assert link1["backref"] == "samples"
     assert link1["target_type"] == "project"
-    assert link1["multiplicity"] == "one_to_many"
+    assert link1["multiplicity"] == "many_to_one"
     assert link1["required"] is True
     assert "label" in link1 and link1["label"] is 'part_of'
 
@@ -448,8 +448,8 @@ def test_construct_prop_lipidomics_file(fixture_input_yaml_pass):
     result = construct_props("lipidomics_file", fixture_input_yaml_pass)
     expected = {
         "$ref": "_definitions.yaml#/data_file_properties",
-        "samples": {"$ref": "_definitions.yaml#/to_many"},
-        "assays": {"$ref": "_definitions.yaml#/to_many"},
+        "samples": {"$ref": "_definitions.yaml#/to_one"},
+        "assays": {"$ref": "_definitions.yaml#/to_one"},
         "core_metadata_collections": {"$ref": "_definitions.yaml#/to_one"},
         'cv': {'description': 'Coefficient of variation (%)', 'type': 'number'}
         
@@ -507,7 +507,7 @@ def test_construct_prop_sample(fixture_input_yaml_pass):
             "description": "Free text notes (string)"
         },
         "projects": {
-            "$ref": "_definitions.yaml#/to_many"
+            "$ref": "_definitions.yaml#/to_one"
         }
     }
     assert result == expected
@@ -562,7 +562,7 @@ def fixture_expected_output_lipid():
                     'backref': 'lipidomics_files',
                     'label': 'part_of',
                     'target_type': 'sample',
-                    'multiplicity': 'one_to_many',
+                    'multiplicity': 'many_to_one',
                     'required': True
                 },
                 {
@@ -570,7 +570,7 @@ def fixture_expected_output_lipid():
                     'backref': 'lipidomics_files',
                     'label': 'part_of',
                     'target_type': 'assay',
-                    'multiplicity': 'one_to_many',
+                    'multiplicity': 'many_to_one',
                     'required': True
                 },
                 {
@@ -585,8 +585,8 @@ def fixture_expected_output_lipid():
         }],
         'properties': {
             '$ref': '_definitions.yaml#/data_file_properties',
-            'samples': {'$ref': '_definitions.yaml#/to_many'},
-            'assays': {'$ref': '_definitions.yaml#/to_many'},
+            'samples': {'$ref': '_definitions.yaml#/to_one'},
+            'assays': {'$ref': '_definitions.yaml#/to_one'},
             'core_metadata_collections': {'$ref': '_definitions.yaml#/to_one'},
             'cv': {'description': 'Coefficient of variation (%)', 'type': 'number'}
         },


### PR DESCRIPTION
- Added a new function `flip_multiplicity` to invert the multiplicity of links between "one_to_many" and "many_to_one".
- Updated the `convert_node_links` and `construct_props` functions to utilize the new multiplicity flipping logic, ensuring correct link properties are generated.
- Adjusted corresponding test cases to reflect the changes in multiplicity values.