### PR TITLE
feat: use special project link definitions for project foreign key re…

### DIFF
--- a/src/gen3schemadev/converter.py
+++ b/src/gen3schemadev/converter.py
@@ -307,6 +307,10 @@ def create_link_prop(target_node: str, multiplicity: str) -> dict:
     """
     Create a property dictionary for a link to another node.
 
+    Links targeting 'project' use the special 'to_one_project' / 'to_many_project'
+    definitions because the project foreign key is identified by 'id' or 'code'
+    (foreign_key_project), not the standard 'id' or 'submitter_id' (foreign_key).
+
     Args:
         target_node: The name of the target node.
         multiplicity: The multiplicity of the link (e.g., 'one_to_one', 'one_to_many').
@@ -314,9 +318,14 @@ def create_link_prop(target_node: str, multiplicity: str) -> dict:
     Returns:
         A dictionary representing the link property for the schema.
     """
+    formatted = format_multiplicity(multiplicity)
+    if target_node == "project":
+        ref = f"_definitions.yaml#/{formatted}_project"
+    else:
+        ref = f"_definitions.yaml#/{formatted}"
     link_prop = {
         link_suffix(target_node): {
-            "$ref": f"_definitions.yaml#/{format_multiplicity(multiplicity)}"
+            "$ref": ref
         }
     }
     return link_prop

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -211,6 +211,31 @@ def test_create_link_prop():
     assert prop3["weird_nodes"]["$ref"] == "_definitions.yaml#/to_one"
 
 
+def test_create_link_prop_project():
+    """
+    When a node links to 'project', the property $ref must use the special
+    'to_one_project' or 'to_many_project' definition rather than the generic
+    'to_one'/'to_many'. This is because 'project' uses a different foreign key
+    schema (foreign_key_project, identified by 'id' or 'code') compared to
+    the standard foreign_key (identified by 'id' or 'submitter_id').
+    """
+    prop_one = create_link_prop("project", "one_to_one")
+    assert "projects" in prop_one
+    assert prop_one["projects"]["$ref"] == "_definitions.yaml#/to_one_project"
+
+    prop_many = create_link_prop("project", "one_to_many")
+    assert "projects" in prop_many
+    assert prop_many["projects"]["$ref"] == "_definitions.yaml#/to_many_project"
+
+    prop_many2 = create_link_prop("project", "many_to_many")
+    assert "projects" in prop_many2
+    assert prop_many2["projects"]["$ref"] == "_definitions.yaml#/to_many_project"
+
+    prop_one2 = create_link_prop("project", "many_to_one")
+    assert "projects" in prop_one2
+    assert prop_one2["projects"]["$ref"] == "_definitions.yaml#/to_one_project"
+
+
 
 def test_get_properties(fixture_input_yaml_pass):
     result = get_properties("lipidomics_file", fixture_input_yaml_pass)
@@ -526,7 +551,7 @@ def test_construct_prop_sample(fixture_input_yaml_pass):
             "description": "Free text notes (string)"
         },
         "projects": {
-            "$ref": "_definitions.yaml#/to_one"
+            "$ref": "_definitions.yaml#/to_one_project"
         }
     }
     assert result == expected


### PR DESCRIPTION
…ferences

Modify create_link_prop to use 'to_one_project' and 'to_many_project' definitions when linking to 'project' nodes, as project uses foreign_key_project (id/code) instead of standard foreign_key (id/submitter_id). Add comprehensive tests covering all multiplicity scenarios for project links.