### PR TITLE
feat!: safe-by-default generate, preset extension, and a dictionary-repo strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,21 @@ This repository aims to provide the documentation, learning materials, and softw
 ## Using Gen3SchemaDev as a data modelling tool
 - [Quickstart](docs/gen3schemadev/quickstart.md)
 - [Guide to creating your first dictionary](docs/gen3schemadev/first_dictionary.md)
+- [Running a Gen3 dictionary repository](docs/gen3schemadev/dictionary_repo.md)
 - [Troubleshooting](docs/gen3schemadev/troubleshooting.md)
+
+### `generate` does not overwrite your files
+
+`gen3schemadev generate` never overwrites existing files by default. Generating into an empty folder works as it always has; generating into a folder that already contains files stops and lists exactly what it would have replaced, along with the ways forward.
+
+This matters because a dictionary repository can be run in more than one way. Some treat the `input_yaml` as the source of truth and regenerate from it. Others generate once and then edit the Gen3 schemas directly, at which point the generated files *are* the dictionary. The tool cannot tell which you are doing, and guessing wrong destroys work.
+
+- `--input-driven` — the `input_yaml` is the source of truth; regenerate everything, and fail if the folder holds a file the input cannot produce
+- `--only <node>` — regenerate named nodes, leaving every other file untouched
+- `--check` — report whether the folder still matches the input, write nothing, exit non-zero on drift. This is the CI gate
+- `--force` — overwrite everything, discarding any hand edits
+
+Nodes may also `extend` the packaged `program`, `project` and `core_metadata_collection` presets, adding properties while inheriting the node-level settings other Gen3 microservices depend on. See [Running a Gen3 dictionary repository](docs/gen3schemadev/dictionary_repo.md).
 
 ### Null description placeholders
 

--- a/docs/gen3schemadev/dictionary_repo.md
+++ b/docs/gen3schemadev/dictionary_repo.md
@@ -1,0 +1,240 @@
+# Running a Gen3 Dictionary Repository
+
+This guide is about the repository that holds your dictionary, rather than the modelling itself.
+It covers the question that causes the most trouble in practice: **where is the source of truth?**
+
+A dictionary repository usually contains two things that describe the same model — an `input_yaml`
+file, and the folder of `Gen3 Schema` files generated from it. Both get committed. Nothing forces
+them to agree. Once they disagree, it is genuinely hard to tell which one is real, and the answer
+tends to be discovered months later by someone who was not there when it happened.
+
+Pick a workflow below, say so in your README, and let the tooling enforce it.
+
+---
+
+## Which workflow are you in?
+
+| You want to... | Workflow | Command you run | What CI enforces |
+|---|---|---|---|
+| Describe the model in one readable file and regenerate from it | **Input-driven** | `generate --input-driven` | `generate --check` passes |
+| Edit `Gen3 Schema` files directly, using their full expressiveness | **Schema-first** | `validate` and `bundle` only | `validate` passes |
+| Scaffold with an `input_yaml`, then take over the YAMLs by hand | **Bootstrap, then fork** | `generate` once, then delete the input | `validate` passes |
+
+If you cannot answer "where is the source of truth in this repository?" in one sentence, that is the
+problem this page exists to fix.
+
+---
+
+## Input-driven
+
+The `input_yaml` is the source of truth. The generated `Gen3 Data Dictionary` is a build artefact
+that happens to be committed, and nobody edits it by hand.
+
+- Best when the model is mostly ordinary nodes and properties, and you value reviewable diffs. A
+  pull request shows a few lines of intent in the input file rather than hundreds of generated lines.
+- Costs you the parts of Gen3 the input language does not express. Most of these now have an answer
+  — see [Extending the packaged presets](#extending-the-packaged-presets) below.
+
+```bash
+gen3schemadev generate -i dictionary/input_dd.yaml -o dictionary/schema/ --input-driven
+gen3schemadev validate -y dictionary/schema
+gen3schemadev bundle -i dictionary/schema -f dictionary/schema/dictionary.json
+```
+
+`--input-driven` says regeneration is expected and safe. It overwrites without complaint, and it
+treats a file it cannot regenerate as an error rather than a warning — which is the point, because
+in this workflow such a file should not exist.
+
+**Use one dictionary folder.** A separate "test" and "production" folder is a common habit here, but
+in an input-driven repository the two are always identical, so it doubles the size of every diff
+without ever being used. Use a branch instead: your branch is the test dictionary, `main` is
+production. That is what branches are for, and unlike a folder a branch cannot be left half-promoted.
+
+---
+
+## Schema-first
+
+The `Gen3 Data Dictionary` folder is the source of truth. There is no `input_yaml`, and `generate`
+is not part of your workflow at all.
+
+- Best when you need the full expressiveness of Gen3 schemas, or when the dictionary was inherited
+  from somewhere else.
+- Costs you the readable overview. Reviewing a change means reading generated-style YAML.
+
+```bash
+gen3schemadev validate -y dictionary/schema
+gen3schemadev bundle -i dictionary/schema -f dictionary/schema/dictionary.json
+```
+
+Nothing about this is second-class. If it is how your repository works, write that in the README so
+nobody arrives later, finds no input file, and assumes one has gone missing.
+
+---
+
+## Bootstrap, then fork
+
+Use the `input_yaml` to sketch the shape of the model — nodes, links, the bulk of the properties —
+then generate once and hand-edit from there.
+
+Be clear-eyed about what this is: **after the fork you are schema-first.** The `input_yaml` is
+scaffolding that has served its purpose, not a fallback you can quietly regenerate from later.
+
+```bash
+# 1. Sketch the model, then generate once
+gen3schemadev generate -i input_dd.yaml -o dictionary/schema/
+
+# 2. Check you are happy with the result
+gen3schemadev validate -y dictionary/schema
+
+# 3. Commit the fork explicitly, so the intent is recorded
+git rm input_dd.yaml
+git commit -m "chore: fork the dictionary from its input; the YAMLs are now the source of truth"
+```
+
+Deleting the input file is the important step, and it is worth doing deliberately rather than
+leaving it lying around. A stale input file left in a repository is read by the next person as a
+description of the model. It is not — it is a description of what the model looked like on the day
+someone stopped using it. Two real repositories have been bitten by exactly this: one carried a node
+YAML that no input could reproduce, which kept being bundled and deployed long after the input
+stopped mentioning it; another committed an input file that had stopped parsing altogether and
+nobody noticed for weeks, because the generated files were still sitting there looking healthy.
+
+If you want to keep the input file for reference, keep it somewhere that cannot be mistaken for a
+build input — `reference/`, with a comment at the top saying when it was forked and that it is no
+longer authoritative.
+
+### Regenerating one node after forking
+
+You do not have to choose between "regenerate everything" and "never regenerate". `--only` rewrites
+the nodes you name and leaves every other file untouched:
+
+```bash
+gen3schemadev generate -i input_dd.yaml -o dictionary/schema/ --only biospecimen
+```
+
+---
+
+## generate never overwrites by default
+
+Running `generate` into a folder that already contains files stops with an error listing exactly
+what it would have replaced, and the ways forward. This is deliberate: the tool cannot tell which
+workflow you are in, and guessing wrong destroys work.
+
+The four ways forward are `--input-driven`, `--only`, deleting the input file to go schema-first,
+and `--force`. Only `--force` discards hand edits, and the message says so.
+
+---
+
+## Extending the packaged presets
+
+Gen3 ships three nodes its own microservices depend on: `program`, `project` and
+`core_metadata_collection`. Their schemas carry settings the input language cannot express — the
+properties Gen3 manages rather than the submitter, `project`'s uniqueness on `code` rather than
+`submitter_id`, defaults for the project state machine, and Data Use Ontology term identifiers on
+the consent codes.
+
+Declaring one of these as an ordinary node rebuilds it from generic defaults and silently drops all
+of that. Use `extends` instead, and declare only what you are adding:
+
+```yaml
+nodes:
+  - name: project
+    extends: project
+    properties:
+      - name: institute_name
+        description: "Institution leading the study."
+        type: string
+      - name: ethics_approval_id
+        description: "Ethics approval identifier covering these samples."
+        type: string
+```
+
+Everything you declare overrides the preset; everything you omit is inherited. `generate` prints
+what it inherited, overrode and added, so the merge is visible in your terminal and in CI logs
+rather than being something you have to take on trust.
+
+---
+
+## Checking for drift
+
+`generate --check` regenerates in memory, compares against what is committed, writes nothing, and
+exits non-zero if they disagree. It reports three distinct problems:
+
+- **Changed** — the file on disk differs from what the input produces. Someone hand-edited it, or
+  the input changed without regenerating.
+- **Missing** — the input describes a node that is not in the folder. It will not be deployed.
+- **Orphaned** — a file the input cannot produce. It cannot be regenerated, but `bundle` still
+  includes it, so it ships and is deployed regardless.
+
+In an input-driven repository all three are failures. In a schema-first one, `--check` is not
+meaningful — validate instead.
+
+### Continuous integration
+
+For an input-driven repository, this is the job that keeps the two sources honest:
+
+```yaml
+name: Dictionary
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install poetry && poetry install
+      - name: Dictionary matches its input
+        run: poetry run gen3schemadev generate -i dictionary/input_dd.yaml -o dictionary/schema/ --check
+      - name: Dictionary is valid
+        run: poetry run gen3schemadev validate -y dictionary/schema
+```
+
+For a schema-first repository, drop the first step and keep the second.
+
+---
+
+## Versioning
+
+Pick one canonical version and derive the rest. Three separate version numbers that disagree is a
+real state repositories reach: one had `1.0.1` in `pyproject.toml`, `1.3.0` in `_settings.yaml`, and
+a most-recent git tag of `v1.2.0`.
+
+The recommendation is that the dictionary version is canonical:
+
+- **Input-driven** — the `version` field at the top of your `input_yaml`. `generate` copies it into
+  `_settings.yaml` as `_dict_version`, so the two cannot drift.
+- **Schema-first** — `_dict_version` in `_settings.yaml`, edited directly.
+
+Tag releases to match (`v1.3.0` for `_dict_version: 1.3.0`). Leave `pyproject.toml`'s version out of
+it — it describes the tooling in the repository, not the dictionary, and trying to keep it in step
+adds a step everyone forgets.
+
+---
+
+## The bundled schema is an external contract
+
+The `Gen3 Bundled Schema` is fetched by whatever deploys your model, usually by URL. That means
+**the folder name and the filename are part of your deployment contract**, not internal detail.
+
+Renaming `dictionary/prod_dict/` or `your_schema.json` breaks deployment silently — the file simply
+stops being where something else expects it, and nothing in this repository will tell you. If you
+need to rename, find the consumer first.
+
+The corollary is that consolidating folders is safe as long as the surviving folder keeps the name
+the deployment already fetches.
+
+---
+
+## Reviewing dictionary changes
+
+Generated dictionaries produce large pull requests. A change of a few lines in an input file can
+touch fifty generated files, and the important part is invisible among them.
+
+- Review the `input_yaml` diff, and treat the generated files as build output.
+- Let CI assert the generated files match, so nobody has to read them to be sure.
+- Do not commit the same dictionary twice under different folder names. If a reviewer has to read
+  every change in duplicate, they will stop reading — which is how a broken input file survived a
+  review and two subsequent commits.

--- a/docs/gen3schemadev/first_dictionary.md
+++ b/docs/gen3schemadev/first_dictionary.md
@@ -29,7 +29,7 @@
 ***
 
 ## Pre-requisites
-- `python v3.12.10` or higher
+- `python v3.9.5` or higher (`3.12.10` recommended; CI tests 3.9 through 3.12)
 - `poetry v2.1.3` or higher 
 - `docker compose` (optional for dictionary visualisation)
 
@@ -44,7 +44,7 @@ A single node in the gen3 graph model can be represented as a single yaml file c
 Therefore the gen3 data model can be represented as a either a collection of yaml files (schemas) or a single json file (bundled schema).
 
 For the purpose of this guide we will use the following terminology:
-- [`Gen3 Schema`](../../tests/gen3_schema/examples/yaml/lipidomics_file.yaml): A single yaml or json file that defines a single node in the data model. [Learn More](schemas.md)
+- [`Gen3 Schema`](../../tests/gen3_schema/examples/yaml/lipidomics_file.yaml): A single yaml or json file that defines a single node in the data model. [Learn More](../gen3_data_modelling/schemas.md)
 - [`Gen3 Data Dictionary`](../../tests/gen3_schema/examples/yaml/): A folder containing multiple yaml files for each node in the data model.
 - [`Gen3 Bundled Schema`](../../tests/gen3_schema/examples/json/schema_dev.json): A json file containing a dictionary of jsonschemas for each node in the data model.
 

--- a/docs/gen3schemadev/first_dictionary.md
+++ b/docs/gen3schemadev/first_dictionary.md
@@ -436,6 +436,25 @@ arguments:
 
 This will generate a folder of gen3 schemas in the `gen3_data_dictionary` directory.
 
+#### Regenerating after you change the input_yaml
+
+Throughout this guide we keep coming back to the input_yaml, changing it, and regenerating. That
+makes this tutorial an **input-driven** dictionary: the input_yaml is the source of truth, and the
+folder of gen3 schemas is rebuilt from it.
+
+`generate` will not overwrite an existing folder unless you say so, because in other projects those
+files may hold hand edits it knows nothing about. Since we do want to regenerate from the input
+every time, use `--input-driven` from here on:
+
+```bash
+gen3schemadev generate -i input_example.yml -o gen3_data_dictionary/ --input-driven
+```
+
+*This is a choice about how your repository works rather than a detail of this tutorial, and it is
+worth making deliberately. [Running a Gen3 Dictionary Repository](dictionary_repo.md) covers the
+alternatives — chiefly editing the gen3 schemas directly once they exist, which is a perfectly good
+way to work but a different one.*
+
 ### 7. Validating the `Gen3 Data Dictionary`
 Now that we have the `Gen3 Data Dictionary`, we can validate it using the `gen3schemadev validate` command.
 

--- a/docs/gen3schemadev/quickstart.md
+++ b/docs/gen3schemadev/quickstart.md
@@ -75,7 +75,7 @@ gen3schemadev generate -i input_example.yaml -o gen3_data_dictionary/ --check
 
 ## 4. Validate schema
 - After you are happy with the folder of gen3 schemas, you can validate them using the `gen3schemadev validate` command.
-- This will do two things, first it will do a validation against the [gen3 metaschema](../../src/gen3schemadev/schema/schema_templates/gen3_metaschema.yaml) and secondly it will do business rule validation based on the logic in the [`rule_validator.py` module](../../src/gen3schemadev/validators/rule_validator.py) 
+- This will do two things, first it will do a validation against the [gen3 metaschema](../../src/gen3schemadev/schema/schema_templates/gen3_metaschema.yml) and secondly it will do business rule validation based on the logic in the [`rule_validator.py` module](../../src/gen3schemadev/validators/rule_validator.py) 
 ```bash
 gen3schemadev validate -y gen3_data_dictionary
 ```

--- a/docs/gen3schemadev/quickstart.md
+++ b/docs/gen3schemadev/quickstart.md
@@ -1,7 +1,7 @@
 # Quickstart
 
 ## Pre-requisites
-- `python v3.12.10` or higher
+- `python v3.9.5` or higher (`3.12.10` recommended; CI tests 3.9 through 3.12)
 - `poetry v2.1.3` or higher
 - `docker compose` (optional for dictionary visualisation)
 
@@ -25,10 +25,52 @@ gen3schemadev init -o input_example.yaml
 gen3schemadev generate -i input_example.yaml -o gen3_data_dictionary/
 ```
 
-### 3.1 Further Gen3 Yaml Configuration (optional)
+### 3.1 Running generate a second time
+- `generate` never overwrites existing files by default. The first run above works because the
+  folder is empty; run it again and it will stop and list what it would have replaced.
+- This is deliberate. Those files may contain edits that your `input_yaml` knows nothing about, and
+  the tool cannot tell whether you meant to keep them.
+- Which flag you want depends on how your repository works:
+```bash
+# The input_yaml is the source of truth - regenerate from it every time
+gen3schemadev generate -i input_example.yaml -o gen3_data_dictionary/ --input-driven
+
+# Regenerate a single node, leaving every other file untouched
+gen3schemadev generate -i input_example.yaml -o gen3_data_dictionary/ --only subject
+
+# Overwrite everything - this discards any hand edits in the folder
+gen3schemadev generate -i input_example.yaml -o gen3_data_dictionary/ --force
+```
+- *If you are not sure which of these you want, read [Running a Gen3 Dictionary Repository](dictionary_repo.md). It is short, and it saves a lot of confusion later.*
+
+### 3.2 Further Gen3 Yaml Configuration (optional)
 - This step is for advanced users that want to edit gen3 Json Schemas manually.
 - This step provides advanced features and is how gen3 schemas are usually modified.
 - You can learn more about how to modify gen3 schemas [here](../gen3_data_modelling/dictionary_structure.md).
+- If you go down this path, the gen3 schemas become your source of truth rather than the
+  `input_yaml`. Delete the `input_yaml` once you are done with it so it cannot mislead the next
+  person — see [Bootstrap, then fork](dictionary_repo.md#bootstrap-then-fork).
+
+### 3.3 Adding properties to program, project or core_metadata_collection
+- These three nodes carry settings that other gen3 microservices rely on, so declaring one as an
+  ordinary node rebuilds it from generic defaults and drops those settings.
+- Use `extends` to add properties while inheriting everything else:
+```yaml
+nodes:
+  - name: project
+    extends: project
+    properties:
+      - name: institute_name
+        description: "Institution leading the study."
+        type: string
+```
+
+### 3.4 Checking a dictionary still matches its input
+- `--check` regenerates in memory, compares against the folder, writes nothing, and exits non-zero
+  if they disagree. This is the command to run in CI.
+```bash
+gen3schemadev generate -i input_example.yaml -o gen3_data_dictionary/ --check
+```
 
 
 ## 4. Validate schema

--- a/docs/gen3schemadev/troubleshooting.md
+++ b/docs/gen3schemadev/troubleshooting.md
@@ -6,7 +6,7 @@ After filling out the `input_yaml` file with your intended data model, running t
 
 ## What the Pydantic error looks Like
 
-When validation fails, Pydantic generates a detailed error output that shows exactly where problems occurred. Here's the complete error output generated from the example input file [input_example_fail.yml](../../examples/input/input_example_fail.yml):
+When validation fails, Pydantic generates a detailed error output that shows exactly where problems occurred. Here's the complete error output generated from the example input file [input_example_fail.yml](../../tests/input_example_fail.yml):
 
 ```
 Traceback (most recent call last):
@@ -61,7 +61,7 @@ Each error entry contains several key components that help identify and fix issu
 
 ## Breaking Down the Four Validation Errors
 
-The following sections examine each error from [input_example_fail.yml](../../examples/input/input_example_fail.yml) and show how to fix them.
+The following sections examine each error from [input_example_fail.yml](../../tests/input_example_fail.yml) and show how to fix them.
 
 ### Error 1: Invalid Version Format
 
@@ -73,7 +73,7 @@ version
 
 **Location Path:** `version` → This refers to the top-level `version` field.
 
-**Problematic YAML (from [input_example_fail.yml](../../examples/input/input_example_fail.yml)):**
+**Problematic YAML (from [input_example_fail.yml](../../tests/input_example_fail.yml)):**
 ```yaml
 version: v0.1.0
 ```
@@ -97,7 +97,7 @@ url
 
 **Location Path:** `url` → This refers to the top-level `url` field.
 
-**Problematic YAML (from [input_example_fail.yml](../../examples/input/input_example_fail.yml)):**
+**Problematic YAML (from [input_example_fail.yml](../../tests/input_example_fail.yml)):**
 ```yaml
 url: link-to-data-portal
 ```
@@ -121,7 +121,7 @@ nodes.0.category
 
 **Location Path:** `nodes.0.category` → Find the `nodes` field, go to the **first entry** (index 0), then locate the `category` field within that entry.
 
-**Problematic YAML (from [input_example_fail.yml](../../examples/input/input_example_fail.yml)):**
+**Problematic YAML (from [input_example_fail.yml](../../tests/input_example_fail.yml)):**
 ```yaml
 nodes:
 - name: project          # This is nodes[0] - the first item
@@ -151,7 +151,7 @@ links.0.multiplicity
 
 **Location Path:** `links.0.multiplicity` → Find the `links` field, go to the **first entry** (index 0), then locate the `multiplicity` field within that entry.
 
-**Problematic YAML (from [input_example_fail.yml](../../examples/input/input_example_fail.yml)):**
+**Problematic YAML (from [input_example_fail.yml](../../tests/input_example_fail.yml)):**
 ```yaml
 links:
 - parent: project          # This is links[0] - the first item
@@ -173,7 +173,7 @@ links:
 
 ## Additional Issues in the Example YAML
 
-Beyond the four validation errors shown, [input_example_fail.yml](../../examples/input/input_example_fail.yml) contains other problems that may not trigger validation errors but will cause issues:
+Beyond the four validation errors shown, [input_example_fail.yml](../../tests/input_example_fail.yml) contains other problems that may not trigger validation errors but will cause issues:
 
 **Typo in property key:**
 ```yaml
@@ -186,6 +186,82 @@ Beyond the four validation errors shown, [input_example_fail.yml](../../examples
 - name: sample_id
   type: strings  # Should be "string" (singular)
 ```
+
+***
+
+
+# Errors from `generate` itself
+
+The errors above come from validating your `input_yaml`. These come from `generate` deciding what it
+is allowed to do to your output folder.
+
+## "Refusing to overwrite N existing files"
+
+**Error message:** `Refusing to overwrite 14 existing files in dictionary/`
+
+**Cause:** `generate` never overwrites existing files by default, because they may contain edits your
+`input_yaml` knows nothing about. This is not a failure — it is the tool declining to guess.
+
+**Fix:** pick the option that matches how your repository works. The message lists all four:
+
+- `--input-driven` — your `input_yaml` is the source of truth, so regenerating is normal and safe
+- `--only <node>` — regenerate one node, leaving every other file untouched
+- delete the `input_yaml` and edit the gen3 schemas directly from now on
+- `--force` — overwrite everything, **discarding any hand edits** in those files
+
+If you are unsure, [Running a Gen3 Dictionary Repository](dictionary_repo.md) walks through the
+choice. Guessing here is how people lose an afternoon of hand edits.
+
+## "N files are not produced by this input"
+
+**Error message:** `1 file in dictionary/ is not produced by this input`
+
+**Cause:** the folder contains a gen3 schema that your `input_yaml` does not describe — usually a
+node that was removed from the input, or one written by hand. It cannot be regenerated, but `bundle`
+still includes it, so it ships in the `Gen3 Bundled Schema` and is deployed.
+
+**Fix:** if it is a deliberate hand-written node, nothing is wrong and this stays a warning. If you
+expected your input to produce it, either add the node back to the input or delete the file. Under
+`--input-driven` this is an error rather than a warning, because that flag asserts the input
+describes the whole dictionary.
+
+## "does not match the dictionary generated from ..."
+
+**Error message:** printed by `generate --check`, listing files as Changed, Missing or Orphaned.
+
+**Cause:** the committed dictionary and the `input_yaml` have drifted apart. Each category has a
+different fix:
+
+- **Changed** — the file was hand-edited, or the input changed and nobody regenerated
+- **Missing** — the input describes a node that is not in the folder, so it will not be deployed
+- **Orphaned** — a file the input cannot produce, which still ships in the bundle
+
+**Fix:** regenerate for Changed and Missing. For Orphaned, decide whether the node belongs in the
+input or should be deleted. `--check` writes nothing, so it is always safe to run first.
+
+## "is not valid YAML at line N"
+
+**Error message:** `input_dd.yaml is not valid YAML at line 1031, column 11` followed by
+`mapping values are not allowed here`
+
+**Cause:** a punctuation slip. Overwhelmingly the most common one is a missing colon after a node
+name — `- name_of_node` where `- name: name_of_node` was meant.
+
+**Fix:** check the reported line and the few lines above it. YAML reports where parsing became
+impossible, which can be slightly below the line actually at fault. This error is worth taking
+seriously in CI: one repository committed exactly this typo and nobody noticed for weeks, because
+the previously generated files were still present and looked healthy.
+
+## "does not describe a valid data model"
+
+**Error message:** a list of locations such as `nodes.0.category` with an explanation under each.
+
+**Cause:** the file is valid YAML but does not match the input schema — a misspelled field name, a
+missing required field, or a value outside the allowed set.
+
+**Fix:** read the location as a path into your file, so `nodes.0.category` is the category of the
+first node. Note that unknown field names are now rejected rather than ignored, so a typo like
+`descriptoin` fails here instead of silently producing a schema with that field missing.
 
 ***
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,7 +1,7 @@
 # Setup
 
 ## Pre-requisites
-- `python v3.12.10` or higher
+- `python v3.9.5` or higher (`3.12.10` recommended; CI tests 3.9 through 3.12)
 - `poetry v2.1.3` or higher
 - `docker compose` (optional for dictionary visualisation)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Gen3SchemaDev"
-version = "2.6.2"
+version = "3.0.0"
 description = "Tool for data modelling in Gen3"
 authors = [
     {name = "JoshuaHarris391",email = "harjo391@gmail.com"}

--- a/src/gen3schemadev/cli.py
+++ b/src/gen3schemadev/cli.py
@@ -255,6 +255,7 @@ def main():
             print(messages.extends_summary(
                 summary['node'], summary['preset'],
                 summary['inherited'], summary['overridden'], summary['added'],
+                implicit=summary.get('implicit', False),
             ))
 
         if args.check:
@@ -288,7 +289,12 @@ def main():
             if args.input_driven:
                 sys.exit(1)
 
-        written = write_dictionary(files, args.output)
+        try:
+            written = write_dictionary(files, args.output)
+        except OSError as exc:
+            print()
+            print(messages.cannot_write(args.output, exc))
+            sys.exit(1)
         print(f"Wrote {len(written)} files to {args.output}")
         print("Schema generation process complete.")
 

--- a/src/gen3schemadev/cli.py
+++ b/src/gen3schemadev/cli.py
@@ -3,6 +3,9 @@ import logging
 import sys
 import os
 
+import yaml
+from pydantic import ValidationError
+
 from gen3schemadev.schema.gen3_template import (
     get_metaschema,
     generate_gen3_template,
@@ -21,6 +24,14 @@ from importlib.metadata import version
 from gen3schemadev.ddvis import visualise_with_docker
 from gen3schemadev.validators.rule_validator import RuleValidator
 from gen3schemadev.refs import find_null_descriptions
+from gen3schemadev import messages
+from gen3schemadev.generation import (
+    build_dictionary,
+    plan_write,
+    find_orphans,
+    diff_against_disk,
+    write_dictionary,
+)
 
 
 def print_null_description_warning(hits):
@@ -76,6 +87,29 @@ def main():
         "-o", "--output",
         required=True,
         help="Output directory"
+    )
+    generate_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing files, discarding any hand edits in them"
+    )
+    generate_parser.add_argument(
+        "--input-driven",
+        action="store_true",
+        dest="input_driven",
+        help=(
+            "Treat the input file as the source of truth: regenerate everything, "
+            "and fail if the output directory contains files the input cannot produce"
+        )
+    )
+    generate_parser.add_argument(
+        "--only",
+        help="Comma-separated node names to regenerate, leaving all other files untouched"
+    )
+    generate_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report whether the output directory matches the input; write nothing. Exits non-zero on drift"
     )
     generate_parser.add_argument(
         "--debug",
@@ -185,30 +219,77 @@ def main():
         metaschema = get_metaschema()
         converter_template = generate_gen3_template(metaschema)
         print(f"Loading input YAML from: {args.input}")
-        data = load_yaml(args.input)
+        try:
+            data = load_yaml(args.input)
+        except yaml.YAMLError as exc:
+            # A punctuation slip in the input used to surface as a raw parser
+            # traceback. One consumer repo shipped an unparseable input for
+            # weeks without anyone realising generation had stopped working.
+            print()
+            print(messages.unparseable_input(args.input, exc))
+            sys.exit(1)
         print("Validating input data model...")
-        validated_model = DataModel.model_validate(data)
+        try:
+            validated_model = DataModel.model_validate(data)
+        except ValidationError as exc:
+            print()
+            print(messages.invalid_input(args.input, exc))
+            sys.exit(1)
         node_names = get_node_names(validated_model)
         print(f"Found nodes: {node_names}")
 
-        for node in node_names:
-            print(f"Populating template for node: '{node}'")
-            out_template = populate_template(node, validated_model, converter_template)
-            print(f"Writing output YAML to: {args.output}/{node}.yaml")
-            write_yaml(out_template, f"{args.output}/{node}.yaml")
+        only = None
+        if args.only:
+            only = [n.strip() for n in args.only.split(',') if n.strip()]
+            unknown = set(only) - set(node_names)
+            if unknown:
+                print(messages.only_unknown_nodes(unknown, node_names))
+                sys.exit(1)
 
-        print('Writing auxiliary files')
-        write_yaml(generate_def_template(), f"{args.output}/_definitions.yaml")
-        setting_dict = generate_setting_template()
-        setting_dict['_dict_version'] = validated_model.version
-        write_yaml(setting_dict, f"{args.output}/_settings.yaml")
-        write_yaml(generate_terms_template(), f"{args.output}/_terms.yaml")
-        write_yaml(generate_core_metadata_template(), f"{args.output}/core_metadata_collection.yaml")
-        if 'project' not in node_names:
-            write_yaml(generate_project_template(), f"{args.output}/project.yaml")
-        if 'program' not in node_names:
-            write_yaml(generate_program_template(), f"{args.output}/program.yaml")
+        # Build the whole dictionary before touching disk. If a node is
+        # malformed we fail here, with the existing dictionary untouched,
+        # rather than leaving a half-written directory behind.
+        print("Building dictionary...")
+        files, merge_summaries = build_dictionary(validated_model, converter_template, only=only)
+        for summary in merge_summaries:
+            print(messages.extends_summary(
+                summary['node'], summary['preset'],
+                summary['inherited'], summary['overridden'], summary['added'],
+            ))
 
+        if args.check:
+            diff = diff_against_disk(files, args.output)
+            if diff['changed'] or diff['missing'] or diff['orphans']:
+                print()
+                print(messages.drift_report(
+                    args.output, diff['changed'], diff['missing'], diff['orphans'],
+                    input_path=args.input,
+                ))
+                sys.exit(1)
+            print(f"OK: {args.output} matches {args.input}. {len(files)} files checked.")
+            sys.exit(0)
+
+        plan = plan_write(files, args.output)
+        # --only names exactly which nodes to rewrite, so it carries its own
+        # consent; refusing it would make the flag useless. --force and
+        # --input-driven are the blanket permissions.
+        may_overwrite = args.force or args.input_driven or only is not None
+        if plan['overwrite'] and not may_overwrite:
+            print()
+            print(messages.overwrite_refusal(
+                args.output, plan['overwrite'], plan['create'], args.input
+            ))
+            sys.exit(1)
+
+        orphans = find_orphans(files, args.output) if only is None else []
+        if orphans:
+            print()
+            print(messages.orphan_report(args.output, orphans, as_error=args.input_driven))
+            if args.input_driven:
+                sys.exit(1)
+
+        written = write_dictionary(files, args.output)
+        print(f"Wrote {len(written)} files to {args.output}")
         print("Schema generation process complete.")
 
     elif args.command == "bundle":
@@ -238,6 +319,11 @@ def main():
             schema_dict = read_json(args.bundled)
         elif args.yamls:
             schema_dict = bundle_yamls(args.yamls)
+        else:
+            # Previously this fell through to an unhandled NameError on
+            # schema_dict, which reads as a crash rather than a usage mistake.
+            print(messages.validate_needs_a_target())
+            sys.exit(1)
 
         # Pre-resolution diagnostic: report every null 'description' up front,
         # because the metaschema stage fails on the first resolved node schema,

--- a/src/gen3schemadev/converter.py
+++ b/src/gen3schemadev/converter.py
@@ -353,8 +353,15 @@ def get_properties(node_name: str, data: DataSourceProtocol) -> list[dict]:
     output = []
     if props:
         for prop in props:
+            # by_alias emits the Gen3 spelling of passthrough annotations
+            # (enum_def -> enumDef). Unset annotations are dropped rather than
+            # written out as nulls.
             pdict = {
-                prop.name: {k: v for k, v in prop.model_dump().items() if k != "name"}
+                prop.name: {
+                    k: v
+                    for k, v in prop.model_dump(by_alias=True).items()
+                    if k != "name" and v is not None
+                }
             }
             
             output.append(pdict)
@@ -744,17 +751,21 @@ def populate_template(node_name: str, input_data: DataSourceProtocol, template: 
         ValueError: If the node is not found in input_data.
     """
     ent = get_node_data(node_name, input_data)
-    ent_dict = ent.model_dump()
+    # by_alias so node-level overrides carry their Gen3 spelling
+    # (system_properties -> systemProperties). exclude_none so a field the user
+    # left unset inherits the template default instead of overwriting it with
+    # null.
+    ent_dict = ent.model_dump(by_alias=True, exclude_none=True)
     output_schema = template.copy()
     namespace = str(input_data.model_dump()['url'])
-    
+
     # add node name as title
     output_schema['title'] = ent.name
     output_schema['namespace'] = namespace
-    
+
     # Check if node is a file category
     file_node = is_file_node(node_name, input_data)
-    
+
     # Populate template with node data
     for key, value in ent_dict.items():
         if key == 'name':
@@ -763,19 +774,29 @@ def populate_template(node_name: str, input_data: DataSourceProtocol, template: 
             output_schema[key] = get_category(node_name, input_data)
         elif key == 'properties':
             output_schema[key] = construct_props(node_name, input_data)
+        elif key == 'extends':
+            # A directive for the merge step, not a Gen3 schema key.
+            continue
         elif key in output_schema:
             output_schema[key] = value
         else:
             logger.debug(f"Key '{key}' from node '{node_name}' not found in template")
-    
-    # add required props
-    props = get_properties(node_name, input_data)
-    required_props = get_required_prop_names(props)
-    if required_props:
-        required_props.append('submitter_id')
-        required_props.append('type')
-        output_schema['required'] = required_props
-    
+
+    # Required properties. An explicit node-level `required` list wins; falling
+    # back to per-property `required: true` flags preserves the older input
+    # style. submitter_id and type are always required by Gen3.
+    if ent.required is not None:
+        output_schema['required'] = list(dict.fromkeys(
+            [*ent.required, 'submitter_id', 'type']
+        ))
+    else:
+        props = get_properties(node_name, input_data)
+        required_props = get_required_prop_names(props)
+        if required_props:
+            required_props.append('submitter_id')
+            required_props.append('type')
+            output_schema['required'] = required_props
+
     # Process and add links
     links = get_node_links(node_name, input_data)
     converted_links = convert_node_links(links)

--- a/src/gen3schemadev/generation.py
+++ b/src/gen3schemadev/generation.py
@@ -11,6 +11,8 @@ detection - is built on top of that complete in-memory picture.
 import copy
 import logging
 import os
+import shutil
+import tempfile
 
 import yaml
 
@@ -67,7 +69,7 @@ def load_preset(name):
     return copy.deepcopy(PRESET_LOADERS[name]())
 
 
-def merge_onto_preset(node_model, node_name, validated_model):
+def merge_onto_preset(node_model, node_name, validated_model, preset=None):
     """
     Merge a declared node onto the packaged preset it extends.
 
@@ -82,17 +84,24 @@ def merge_onto_preset(node_model, node_name, validated_model):
         node_model: The validated input node declaring `extends`.
         node_name: The node's name.
         validated_model: The whole validated data model, for link lookups.
+        preset: Preset to merge onto. Defaults to the node's own `extends`.
 
     Returns:
         A tuple of (merged schema dict, summary dict describing the merge).
     """
-    preset = load_preset(node_model.extends)
+    preset_name = preset or node_model.extends
+    preset = load_preset(preset_name)
 
     # exclude_unset tells us precisely which keys the author typed, as opposed
     # to which merely have defaults. Without it every unwritten field would
     # look like a deliberate override.
+    #
+    # mode='json' resolves enums to their string values. Without it a declared
+    # `category` arrives as a CategoryEnum member, which yaml.safe_dump cannot
+    # represent, so generation fails at the very last step with a representer
+    # error that says nothing about the input.
     declared = node_model.model_dump(
-        by_alias=True, exclude_none=True, exclude_unset=True
+        by_alias=True, exclude_none=True, exclude_unset=True, mode='json'
     )
 
     overridden = []
@@ -118,7 +127,7 @@ def merge_onto_preset(node_model, node_name, validated_model):
 
     inherited = [k for k in _MERGEABLE_NODE_KEYS if k in preset and k not in overridden]
     summary = {
-        'preset': node_model.extends,
+        'preset': preset_name,
         'inherited': inherited,
         'overridden': overridden,
         'added': added,
@@ -164,9 +173,26 @@ def build_dictionary(validated_model, converter_template, only=None):
 
     for name in targets:
         node_model = nodes_by_name.get(name)
-        if node_model is not None and node_model.extends:
-            merged, summary = merge_onto_preset(node_model, name, validated_model)
+        # Declaring a node that shares a preset's name means adding to it, not
+        # replacing it. Building such a node from generic defaults would drop
+        # the settings Gen3 microservices depend on, and the resulting file
+        # still looks valid, so the loss is silent. Extending is therefore the
+        # default, and it is reported so it is never a surprise.
+        implicit = (
+            node_model is not None
+            and node_model.extends is None
+            and name in PRESET_LOADERS
+        )
+        preset_name = node_model.extends if node_model is not None else None
+        if implicit:
+            preset_name = name
+
+        if preset_name:
+            merged, summary = merge_onto_preset(
+                node_model, name, validated_model, preset=preset_name
+            )
             summary['node'] = name
+            summary['implicit'] = implicit
             summaries.append(summary)
             files[f"{name}.yaml"] = merged
         else:
@@ -333,9 +359,39 @@ def diff_against_disk(files, output_dir):
     }
 
 
+def unwritable_targets(files, output_dir):
+    """
+    Find existing files that could not be replaced.
+
+    Checked before anything is written, so a permissions problem is reported as
+    a refusal rather than discovered halfway through and left as a half-updated
+    dictionary.
+
+    Args:
+        files: The in-memory dictionary from build_dictionary.
+        output_dir: Target directory.
+
+    Returns:
+        A sorted list of filenames that exist but cannot be written.
+    """
+    blocked = []
+    for filename in files:
+        path = os.path.join(output_dir, filename)
+        if os.path.exists(path) and not os.access(path, os.W_OK):
+            blocked.append(filename)
+    return sorted(blocked)
+
+
 def write_dictionary(files, output_dir):
     """
-    Write a fully-built dictionary to disk.
+    Write a fully-built dictionary to disk without leaving it half-updated.
+
+    Files are staged into a temporary directory alongside the target and only
+    then moved into place. Writing directly would mean that a failure partway
+    through - a read-only file, a full disk - left some files updated and the
+    rest stale, which is the one state a dictionary must never be in: it matches
+    neither the input nor the previous commit, and nothing tells you which files
+    are which.
 
     Args:
         files: The in-memory dictionary from build_dictionary.
@@ -343,8 +399,31 @@ def write_dictionary(files, output_dir):
 
     Returns:
         The sorted list of filenames written.
+
+    Raises:
+        PermissionError: If an existing target file cannot be replaced. Raised
+            before anything is written.
     """
     os.makedirs(output_dir, exist_ok=True)
-    for filename, content in sorted(files.items()):
-        write_yaml(content, os.path.join(output_dir, filename))
+
+    blocked = unwritable_targets(files, output_dir)
+    if blocked:
+        raise PermissionError(
+            f"cannot replace existing file(s): {', '.join(blocked)}"
+        )
+
+    # Staged inside the output directory so the final move is a rename within
+    # one filesystem, which cannot half-complete.
+    staging = tempfile.mkdtemp(prefix='.gen3schemadev-', dir=output_dir)
+    try:
+        for filename, content in sorted(files.items()):
+            write_yaml(content, os.path.join(staging, filename))
+        for filename in sorted(files):
+            os.replace(
+                os.path.join(staging, filename),
+                os.path.join(output_dir, filename),
+            )
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
     return sorted(files)

--- a/src/gen3schemadev/generation.py
+++ b/src/gen3schemadev/generation.py
@@ -1,0 +1,350 @@
+"""
+Dictionary generation: planning, preset merging, drift detection, and writing.
+
+The central design decision here is that generation happens entirely in memory
+before a single file is touched. `build_dictionary` either returns a complete
+set of files or raises, so a malformed node cannot leave half a dictionary on
+disk. Everything else in this module - refusing to overwrite, `--check`, orphan
+detection - is built on top of that complete in-memory picture.
+"""
+
+import copy
+import logging
+import os
+
+import yaml
+
+from gen3schemadev.converter import get_node_names, populate_template, construct_props
+from gen3schemadev.schema.gen3_template import (
+    generate_def_template,
+    generate_setting_template,
+    generate_terms_template,
+    generate_core_metadata_template,
+    generate_project_template,
+    generate_program_template,
+)
+from gen3schemadev.utils import write_yaml
+
+logger = logging.getLogger(__name__)
+
+# Files written from packaged templates rather than from the user's nodes.
+# They are never treated as orphans.
+FRAMEWORK_FILES = ('_definitions.yaml', '_settings.yaml', '_terms.yaml')
+
+# Presets a node may extend, and the loader that supplies each one.
+PRESET_LOADERS = {
+    'program': generate_program_template,
+    'project': generate_project_template,
+    'core_metadata_collection': generate_core_metadata_template,
+}
+
+# Node-level keys that a declaring node may override on a preset. `properties`
+# is merged rather than replaced, so it is handled separately.
+_MERGEABLE_NODE_KEYS = (
+    'description', 'category', 'submittable', 'validators',
+    'systemProperties', 'uniqueKeys', 'required', 'namespace',
+    'program', 'project',
+)
+
+
+def load_preset(name):
+    """
+    Load a packaged preset schema by name.
+
+    Args:
+        name: One of the keys in PRESET_LOADERS.
+
+    Returns:
+        A deep copy of the preset, safe for the caller to mutate.
+
+    Raises:
+        ValueError: If the preset is not one gen3schemadev ships.
+    """
+    if name not in PRESET_LOADERS:
+        raise ValueError(
+            f"Unknown preset '{name}'. Available presets: {', '.join(sorted(PRESET_LOADERS))}"
+        )
+    return copy.deepcopy(PRESET_LOADERS[name]())
+
+
+def merge_onto_preset(node_model, node_name, validated_model):
+    """
+    Merge a declared node onto the packaged preset it extends.
+
+    Only what the author actually wrote overrides the preset. Everything else is
+    inherited, which is the whole point: presets carry node-level settings that
+    Gen3 microservices rely on and that the input language cannot express -
+    project's release-related systemProperties, its uniqueKeys on `code`, and the
+    DUO ontology terms on consent_codes. A node that adds two properties must not
+    silently drop any of that.
+
+    Args:
+        node_model: The validated input node declaring `extends`.
+        node_name: The node's name.
+        validated_model: The whole validated data model, for link lookups.
+
+    Returns:
+        A tuple of (merged schema dict, summary dict describing the merge).
+    """
+    preset = load_preset(node_model.extends)
+
+    # exclude_unset tells us precisely which keys the author typed, as opposed
+    # to which merely have defaults. Without it every unwritten field would
+    # look like a deliberate override.
+    declared = node_model.model_dump(
+        by_alias=True, exclude_none=True, exclude_unset=True
+    )
+
+    overridden = []
+    for key in _MERGEABLE_NODE_KEYS:
+        if key in declared:
+            preset[key] = declared[key]
+            overridden.append(key)
+
+    added = []
+    if node_model.properties:
+        # construct_props builds the $ref and link properties too; the preset
+        # already has its own, so take only the properties this node declares.
+        generated_props = construct_props(node_name, validated_model)
+        declared_names = {p.name for p in node_model.properties}
+        preset.setdefault('properties', {})
+        for prop_name in declared_names:
+            if prop_name in generated_props:
+                preset['properties'][prop_name] = generated_props[prop_name]
+                added.append(prop_name)
+
+    if 'required' in declared:
+        preset['required'] = list(dict.fromkeys([*declared['required'], 'submitter_id', 'type']))
+
+    inherited = [k for k in _MERGEABLE_NODE_KEYS if k in preset and k not in overridden]
+    summary = {
+        'preset': node_model.extends,
+        'inherited': inherited,
+        'overridden': overridden,
+        'added': added,
+    }
+    return preset, summary
+
+
+def build_dictionary(validated_model, converter_template, only=None):
+    """
+    Build every file the dictionary consists of, in memory.
+
+    Nothing is written here. If any node fails to build, the caller still has
+    whatever was on disk before, untouched.
+
+    Args:
+        validated_model: The validated input data model.
+        converter_template: Node template derived from the metaschema.
+        only: Optional collection of node names to build. Framework and preset
+            files are skipped when set, so a targeted regeneration touches
+            nothing else.
+
+    Returns:
+        A tuple of (files dict keyed by filename, list of merge summaries).
+
+    Raises:
+        ValueError: If `only` names nodes the input does not define.
+    """
+    node_names = get_node_names(validated_model)
+    nodes_by_name = {n.name: n for n in validated_model.nodes}
+
+    if only is not None:
+        unknown = set(only) - set(node_names)
+        if unknown:
+            raise ValueError(
+                f"--only named nodes not present in the input: {sorted(unknown)}"
+            )
+        targets = [n for n in node_names if n in set(only)]
+    else:
+        targets = list(node_names)
+
+    files = {}
+    summaries = []
+
+    for name in targets:
+        node_model = nodes_by_name.get(name)
+        if node_model is not None and node_model.extends:
+            merged, summary = merge_onto_preset(node_model, name, validated_model)
+            summary['node'] = name
+            summaries.append(summary)
+            files[f"{name}.yaml"] = merged
+        else:
+            files[f"{name}.yaml"] = populate_template(
+                name, validated_model, converter_template
+            )
+
+    # A targeted regeneration deliberately stops here: rewriting the framework
+    # files would defeat the point of --only.
+    if only is not None:
+        return files, summaries
+
+    definitions = generate_def_template()
+    if validated_model.definitions:
+        # Repo-supplied definitions are merged in so custom enums and refs
+        # survive regeneration instead of being clobbered by the template.
+        definitions = _deep_merge(definitions, validated_model.definitions)
+    files['_definitions.yaml'] = definitions
+
+    settings = generate_setting_template()
+    settings['_dict_version'] = validated_model.version
+    files['_settings.yaml'] = settings
+    files['_terms.yaml'] = generate_terms_template()
+
+    # Presets are only injected when the input has not declared the node
+    # itself. This now applies to core_metadata_collection too, which was
+    # previously written unconditionally and silently discarded any
+    # user-declared version.
+    for preset_name, loader in PRESET_LOADERS.items():
+        if preset_name not in node_names:
+            files[f"{preset_name}.yaml"] = loader()
+
+    return files, summaries
+
+
+def _deep_merge(base, overlay):
+    """
+    Recursively merge overlay into a copy of base; overlay wins on conflict.
+
+    Args:
+        base: The starting mapping.
+        overlay: Values to layer on top.
+
+    Returns:
+        A new merged dict; neither input is mutated.
+    """
+    result = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+def serialise(content):
+    """
+    Render a schema exactly as `write_yaml` would write it.
+
+    Keeping this in step with utils.write_yaml is what lets --check compare
+    against the real bytes rather than an approximation of them.
+
+    Args:
+        content: The schema dict.
+
+    Returns:
+        The YAML text that would be written to disk.
+    """
+    return yaml.safe_dump(content, sort_keys=False, indent=2)
+
+
+def existing_yaml_files(output_dir):
+    """
+    List the YAML filenames already present in an output directory.
+
+    Args:
+        output_dir: Directory to inspect.
+
+    Returns:
+        A set of filenames, empty if the directory does not exist.
+    """
+    if not os.path.isdir(output_dir):
+        return set()
+    return {
+        f for f in os.listdir(output_dir)
+        if f.endswith(('.yaml', '.yml'))
+    }
+
+
+def plan_write(files, output_dir):
+    """
+    Work out what writing these files would do to a directory.
+
+    Args:
+        files: The in-memory dictionary from build_dictionary.
+        output_dir: Target directory.
+
+    Returns:
+        A dict with 'overwrite', 'create' and 'orphans' filename lists.
+    """
+    present = existing_yaml_files(output_dir)
+    generated = set(files)
+    return {
+        'overwrite': sorted(present & generated),
+        'create': sorted(generated - present),
+        'orphans': sorted(present - generated),
+    }
+
+
+def find_orphans(files, output_dir):
+    """
+    Find YAML files present on disk that this input does not produce.
+
+    Framework files are excluded: they come from packaged templates, so their
+    presence says nothing about drift.
+
+    Args:
+        files: The in-memory dictionary from build_dictionary.
+        output_dir: Directory to inspect.
+
+    Returns:
+        A sorted list of orphan filenames.
+    """
+    present = existing_yaml_files(output_dir)
+    return sorted(present - set(files) - set(FRAMEWORK_FILES))
+
+
+def diff_against_disk(files, output_dir):
+    """
+    Compare the generated dictionary with what is committed on disk.
+
+    The question being answered is "would regenerating change this file?", so
+    the comparison is against the exact text generation would write. Comparing
+    parsed YAML instead would look more forgiving but would miss real hand
+    edits - a comment added by a developer survives parsing unchanged, yet is
+    destroyed the moment anyone regenerates.
+
+    Args:
+        files: The in-memory dictionary from build_dictionary.
+        output_dir: Directory to compare against.
+
+    Returns:
+        A dict with 'changed', 'missing' and 'orphans' filename lists.
+    """
+    changed = []
+    missing = []
+    for filename, content in files.items():
+        path = os.path.join(output_dir, filename)
+        if not os.path.exists(path):
+            missing.append(filename)
+            continue
+        try:
+            with open(path, 'r') as handle:
+                on_disk = handle.read()
+        except OSError:
+            changed.append(filename)
+            continue
+        if on_disk != serialise(content):
+            changed.append(filename)
+    return {
+        'changed': sorted(changed),
+        'missing': sorted(missing),
+        'orphans': find_orphans(files, output_dir),
+    }
+
+
+def write_dictionary(files, output_dir):
+    """
+    Write a fully-built dictionary to disk.
+
+    Args:
+        files: The in-memory dictionary from build_dictionary.
+        output_dir: Target directory, created if absent.
+
+    Returns:
+        The sorted list of filenames written.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    for filename, content in sorted(files.items()):
+        write_yaml(content, os.path.join(output_dir, filename))
+    return sorted(files)

--- a/src/gen3schemadev/messages.py
+++ b/src/gen3schemadev/messages.py
@@ -179,7 +179,7 @@ def drift_report(output_dir, changed, missing, orphans, input_path=None):
     return "\n".join(lines)
 
 
-def extends_summary(node_name, preset, inherited, overridden, added):
+def extends_summary(node_name, preset, inherited, overridden, added, implicit=False):
     """
     Build the info line describing what an `extends` merge actually did.
 
@@ -193,11 +193,21 @@ def extends_summary(node_name, preset, inherited, overridden, added):
         inherited: Preset keys carried through unchanged.
         overridden: Preset keys the node replaced.
         added: Property names the node contributed.
+        implicit: True when the node did not say `extends` and was merged
+            because it shares a preset's name.
 
     Returns:
         The formatted message string.
     """
-    lines = [f"  '{node_name}' extends the packaged '{preset}' preset"]
+    if implicit:
+        lines = [
+            f"  '{node_name}' shares the name of a packaged preset, so it was merged",
+            f"    onto it rather than replacing it. Building it from scratch would drop",
+            f"    the preset's own properties and the node-level settings Gen3 relies on.",
+            f"    Add 'extends: {preset}' to the node to make this explicit.",
+        ]
+    else:
+        lines = [f"  '{node_name}' extends the packaged '{preset}' preset"]
     if added:
         lines.append(f"    added properties:  {', '.join(sorted(added))}")
     if overridden:
@@ -305,6 +315,36 @@ def invalid_input(input_path, error):
         f"  See: {DOCS_TROUBLESHOOTING}",
     ]
     return "\n".join(lines)
+
+
+def cannot_write(output_dir, error):
+    """
+    Build the error for a dictionary that could not be written.
+
+    Reassures the reader that the existing dictionary is intact, because the
+    obvious worry on seeing a write failure is that the directory has been left
+    half-updated.
+
+    Args:
+        output_dir: The directory being written to.
+        error: The underlying OSError.
+
+    Returns:
+        The formatted message string.
+    """
+    return "\n".join([
+        f"Could not write the dictionary to {output_dir}.",
+        "",
+        f"  {error}",
+        "",
+        "  Your existing dictionary has not been modified. Files are staged and",
+        "  only moved into place once all of them have been written, so a failure",
+        "  part way through cannot leave the directory half updated.",
+        "",
+        "  Check file permissions and available disk space, then run the same",
+        "  command again.",
+        f"  See: {DOCS_TROUBLESHOOTING}",
+    ])
 
 
 def validate_needs_a_target():

--- a/src/gen3schemadev/messages.py
+++ b/src/gen3schemadev/messages.py
@@ -1,0 +1,330 @@
+"""
+User-facing messages for the CLI.
+
+These are built as pure functions so they can be asserted in tests. A message
+that stops the user is part of the tool's behaviour, not decoration: if it
+regresses, someone loses a morning.
+
+Every message follows the same four-part shape:
+
+1. what happened, in plain language
+2. which files or nodes are affected, named explicitly
+3. why the tool stopped, or why this is only a warning
+4. the ways forward, as concrete commands, with destructive ones marked
+
+Each ends with a pointer to the documentation section that explains the
+underlying concept. `tests/test_cli_messages.py` asserts every pointer resolves
+to a real heading, so a message can never send someone to a page that does not
+exist.
+"""
+
+DOCS_DICTIONARY_REPO = "docs/gen3schemadev/dictionary_repo.md"
+DOCS_TROUBLESHOOTING = "docs/gen3schemadev/troubleshooting.md"
+
+# How many filenames to list before collapsing into "(+N more)".
+_MAX_LISTED = 6
+
+
+def _file_list(names, indent="    "):
+    """Format a list of filenames, truncating long lists but keeping the count honest."""
+    names = sorted(names)
+    if len(names) <= _MAX_LISTED:
+        return f"{indent}{', '.join(names)}"
+    shown = ', '.join(names[:_MAX_LISTED])
+    return f"{indent}{shown}, ... (+{len(names) - _MAX_LISTED} more)"
+
+
+def overwrite_refusal(output_dir, would_overwrite, would_create, input_path):
+    """
+    Build the message shown when `generate` would overwrite existing files.
+
+    This is the tool's most important message. A user hits it the second time
+    they ever run generate, which for many people is the moment they decide
+    whether the tool is on their side.
+
+    Args:
+        output_dir: Directory being generated into.
+        would_overwrite: Filenames that already exist and would be replaced.
+        would_create: Filenames that do not exist yet.
+        input_path: Path to the input YAML, used to make the commands copy-pasteable.
+
+    Returns:
+        The formatted message string.
+    """
+    lines = [
+        f"Refusing to overwrite {len(would_overwrite)} existing "
+        f"file{'s' if len(would_overwrite) != 1 else ''} in {output_dir}",
+        "",
+        "  Would overwrite:",
+        _file_list(would_overwrite, indent="    "),
+    ]
+    if would_create:
+        lines += ["  Would create:", _file_list(would_create, indent="    ")]
+    lines += [
+        "",
+        "  generate never overwrites by default, because these files may contain",
+        "  edits that your input file does not know about.",
+        "",
+        "  Choose how this repository works:",
+        "",
+        f"  * {input_path} is the source of truth - regenerate every time:",
+        f"      gen3schemadev generate -i {input_path} -o {output_dir} --input-driven",
+        "",
+        "  * The Gen3 YAMLs are the source of truth - you have bootstrapped them",
+        "    and now edit them directly. Delete the input file so it cannot mislead",
+        f"    the next developer ({input_path}), then use validate and bundle from here on.",
+        "",
+        "  * Regenerate one node and leave everything else alone:",
+        f"      gen3schemadev generate -i {input_path} -o {output_dir} --only <node>",
+        "",
+        "  * Overwrite everything now - THIS DISCARDS ANY HAND EDITS in the files above:",
+        f"      gen3schemadev generate -i {input_path} -o {output_dir} --force",
+        "",
+        f"  See: {DOCS_DICTIONARY_REPO}",
+    ]
+    return "\n".join(lines)
+
+
+def orphan_report(output_dir, orphans, as_error):
+    """
+    Build the message describing files the input cannot produce.
+
+    States the consequence rather than the observation: an orphan is not merely
+    untidy, it is still bundled and still deployed. This is exactly how a stale
+    node kept shipping in a production dictionary long after the input stopped
+    describing it.
+
+    Args:
+        output_dir: Directory that was inspected.
+        orphans: Filenames present but not generated from the input.
+        as_error: True under --input-driven, where an orphan is a failure rather
+            than a warning.
+
+    Returns:
+        The formatted message string.
+    """
+    headline = (
+        f"{len(orphans)} file{'s' if len(orphans) != 1 else ''} in {output_dir} "
+        f"{'is' if len(orphans) == 1 else 'are'} not produced by this input"
+    )
+    lines = [
+        headline,
+        "",
+        _file_list(orphans, indent="    "),
+        "",
+        "  These files cannot be regenerated, but bundle still includes them, so",
+        "  they will ship in the bundled schema and be deployed to Gen3.",
+        "",
+    ]
+    if as_error:
+        lines += [
+            "  Under --input-driven the input is the source of truth, so an",
+            "  unreproducible file is an error.",
+            "",
+            "  Either add the node to your input file, or delete the file if it is",
+            "  no longer part of the model.",
+        ]
+    else:
+        lines += [
+            "  If they are deliberate hand-written nodes, nothing is wrong - this is",
+            "  normal in a schema-first repository. If you expected your input to",
+            "  produce them, the input and the dictionary have drifted apart.",
+        ]
+    lines += ["", f"  See: {DOCS_DICTIONARY_REPO}"]
+    return "\n".join(lines)
+
+
+def drift_report(output_dir, changed, missing, orphans, input_path=None):
+    """
+    Build the `--check` result describing how the dictionary differs from its input.
+
+    Names which side is stale for each category, because "they differ" is not
+    actionable on its own.
+
+    Args:
+        output_dir: Directory that was checked.
+        changed: Files whose generated content differs from what is on disk.
+        missing: Files the input produces that are absent from the directory.
+        orphans: Files present that the input does not produce.
+        input_path: The input file, named in the headline when known.
+
+    Returns:
+        The formatted message string.
+    """
+    source = f" generated from {input_path}" if input_path else ""
+    lines = [f"{output_dir} does not match the dictionary{source}."]
+    lines.append("")
+    if changed:
+        lines += [
+            f"  Changed - on disk differs from generated ({len(changed)}):",
+            _file_list(changed),
+            "    The file was hand-edited, or the input changed without regenerating.",
+            "",
+        ]
+    if missing:
+        lines += [
+            f"  Missing - your input produces these but they are not on disk ({len(missing)}):",
+            _file_list(missing),
+            "    Run generate to create them.",
+            "",
+        ]
+    if orphans:
+        lines += [
+            f"  Orphaned - on disk but not produced by your input ({len(orphans)}):",
+            _file_list(orphans),
+            "    These still ship in the bundle. Add them to the input or delete them.",
+            "",
+        ]
+    lines += [f"  See: {DOCS_DICTIONARY_REPO}"]
+    return "\n".join(lines)
+
+
+def extends_summary(node_name, preset, inherited, overridden, added):
+    """
+    Build the info line describing what an `extends` merge actually did.
+
+    A merge that cannot be seen is a merge nobody can trust. This spells out
+    which preset fields survived untouched and which the node replaced, so the
+    Gen3-critical parts of a preset are visibly accounted for.
+
+    Args:
+        node_name: The declaring node.
+        preset: Name of the preset it extends.
+        inherited: Preset keys carried through unchanged.
+        overridden: Preset keys the node replaced.
+        added: Property names the node contributed.
+
+    Returns:
+        The formatted message string.
+    """
+    lines = [f"  '{node_name}' extends the packaged '{preset}' preset"]
+    if added:
+        lines.append(f"    added properties:  {', '.join(sorted(added))}")
+    if overridden:
+        lines.append(f"    overrode:          {', '.join(sorted(overridden))}")
+    if inherited:
+        lines.append(f"    inherited:         {', '.join(sorted(inherited))}")
+    return "\n".join(lines)
+
+
+def only_unknown_nodes(requested, known):
+    """
+    Build the error for `--only` naming nodes the input does not define.
+
+    Suggests near-matches, because the overwhelmingly common cause is a typo or
+    a node that was renamed in the input.
+
+    Args:
+        requested: Node names that could not be found.
+        known: Every node name the input defines.
+
+    Returns:
+        The formatted message string.
+    """
+    lines = [
+        f"--only named {len(requested)} node{'s' if len(requested) != 1 else ''} "
+        f"that {'are' if len(requested) != 1 else 'is'} not in the input: "
+        f"{', '.join(sorted(requested))}",
+        "",
+    ]
+    for name in sorted(requested):
+        close = [k for k in known if k.startswith(name[:3])] if len(name) >= 3 else []
+        if close:
+            lines.append(f"  '{name}' - did you mean: {', '.join(sorted(close))}?")
+    lines += [
+        "",
+        f"  Nodes defined in this input: {', '.join(sorted(known))}",
+        "",
+        "  Nothing was written.",
+        f"  See: {DOCS_DICTIONARY_REPO}",
+    ]
+    return "\n".join(lines)
+
+
+def unparseable_input(input_path, error):
+    """
+    Build the error for an input file that is not valid YAML.
+
+    Reports the position the parser stopped at, because YAML errors are almost
+    always a punctuation slip a line or two above where they surface - a missing
+    colon after a node name, most commonly.
+
+    Args:
+        input_path: The file that could not be parsed.
+        error: The underlying YAML exception.
+
+    Returns:
+        The formatted message string.
+    """
+    mark = getattr(error, 'problem_mark', None)
+    where = f" at line {mark.line + 1}, column {mark.column + 1}" if mark else ""
+    problem = getattr(error, 'problem', None) or str(error)
+    return "\n".join([
+        f"{input_path} is not valid YAML{where}.",
+        "",
+        f"  {problem}",
+        "",
+        "  A missing colon after a node name is the usual cause, for example",
+        "  '- name_of_node' where '- name: name_of_node' was meant. YAML reports",
+        "  the line where parsing became impossible, which can be slightly below",
+        "  the line actually at fault.",
+        "",
+        "  Nothing was written.",
+        f"  See: {DOCS_TROUBLESHOOTING}",
+    ])
+
+
+def invalid_input(input_path, error):
+    """
+    Build the error for input that parses as YAML but does not match the schema.
+
+    Pydantic's own output is accurate but dense, so it is reproduced under a
+    plain-language heading and a pointer to the guide that decodes it.
+
+    Args:
+        input_path: The file that failed validation.
+        error: The pydantic ValidationError.
+
+    Returns:
+        The formatted message string.
+    """
+    lines = [
+        f"{input_path} is valid YAML but does not describe a valid data model.",
+        "",
+    ]
+    for err in error.errors():
+        location = ".".join(str(part) for part in err.get('loc', ()))
+        lines.append(f"  {location or '<root>'}")
+        lines.append(f"    {err.get('msg', '')}")
+    lines += [
+        "",
+        "  The location above reads as a path into your input file, so",
+        "  'nodes.0.category' means the category of the first node.",
+        "",
+        "  Nothing was written.",
+        f"  See: {DOCS_TROUBLESHOOTING}",
+    ]
+    return "\n".join(lines)
+
+
+def validate_needs_a_target():
+    """
+    Build the usage error for `validate` with neither -b nor -y.
+
+    Previously this path raised an unhandled NameError, which reads as a tool
+    crash rather than a usage mistake.
+
+    Returns:
+        The formatted message string.
+    """
+    return "\n".join([
+        "validate needs something to validate.",
+        "",
+        "  Give it a directory of Gen3 YAML files:",
+        "      gen3schemadev validate -y dictionary/",
+        "",
+        "  or a bundled schema:",
+        "      gen3schemadev validate -b dictionary/schema.json",
+        "",
+        f"  See: {DOCS_TROUBLESHOOTING}",
+    ])

--- a/src/gen3schemadev/schema/input_schema.py
+++ b/src/gen3schemadev/schema/input_schema.py
@@ -1,15 +1,27 @@
-from typing import List, Literal, Optional
-from enum import Enum 
+from typing import Any, Dict, List, Literal, Optional
+from enum import Enum
 from pydantic import (
+    AliasChoices,
     BaseModel,
+    ConfigDict,
     Field,
     field_validator,
+    model_validator,
     AnyUrl,
 )
 
 
+# Presets shipped with gen3schemadev that a node may extend. These carry
+# node-level settings that Gen3 microservices depend on (project's release
+# flags, its uniqueKeys on `code`, the DUO consent_codes enumDef), which the
+# input language cannot otherwise express.
+EXTENDABLE_PRESETS = ('program', 'project', 'core_metadata_collection')
+
+
 class Property(BaseModel):
     """Schema for gen3 property"""
+    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+
     name: str = Field(description="The name of the property.")
     type: Literal[
         'string', 'integer', 'number', 'boolean', 'datetime', 'enum', 'array'
@@ -22,6 +34,36 @@ class Property(BaseModel):
         description="A string list of possible values."
     )
 
+    # Passthrough annotations. These are emitted verbatim alongside the
+    # property so the input language can express the parts of JSON Schema the
+    # formatters do not build themselves.
+    default: Optional[Any] = Field(
+        default=None,
+        description="Default value applied when the property is absent.",
+    )
+    format: Optional[str] = Field(
+        default=None,
+        description="JSON Schema format annotation, e.g. 'date-time'.",
+    )
+    items: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Item schema for 'array' properties. Overrides the default {'type': 'string'}.",
+    )
+    enum_def: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        validation_alias=AliasChoices('enum_def', 'enumDef'),
+        serialization_alias='enumDef',
+        description="Ontology term definitions accompanying an enum, e.g. DUO consent codes.",
+    )
+    pattern: Optional[str] = Field(
+        default=None,
+        description="Regular expression the value must match.",
+    )
+    term: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Term reference block, e.g. {'$ref': '_terms.yaml#/datetime'}.",
+    )
+
     @field_validator('enums')
     def check_enums_for_enum_type(cls, v, info):
         """
@@ -31,9 +73,6 @@ class Property(BaseModel):
         if info.data.get('type') == 'enum' and v is None:
             raise ValueError("The 'enums' field is required when the property type is 'enum'")
         return v
-
-    class ConfigDict:
-        extra = 'forbid'
 
 
 # Inherit from str and Enum to create a string-based enumeration
@@ -61,33 +100,92 @@ class CategoryEnum(str, Enum):
 
 class node(BaseModel):
     """A data node (node) in the model."""
+    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+
     name: str = Field(description="The unique name of the node.")
     description: Optional[str] = Field(default=None, description="A human-readable description of the node.")
-    category: CategoryEnum = Field(description="The category the node belongs to.")
+    category: Optional[CategoryEnum] = Field(
+        default=None,
+        description="The category the node belongs to. Optional when the node extends a preset.",
+    )
     properties: List[Property] = Field(default_factory=list, description="A list of properties for the node.")
-    
-    class ConfigDict:
-        extra = 'forbid'
+
+    extends: Optional[Literal[EXTENDABLE_PRESETS]] = Field(
+        default=None,
+        description=(
+            "Merge this node onto a packaged preset instead of building it from scratch. "
+            "Anything declared here overrides the preset; everything else is inherited."
+        ),
+    )
+
+    # Node-level Gen3 settings. Each of these names a key in the generated
+    # schema; leaving one unset inherits the metaschema default rather than
+    # writing null.
+    submittable: Optional[bool] = Field(default=None, description="Whether data can be submitted to this node.")
+    validators: Optional[List[str]] = Field(default=None, description="Additional validator functions to run.")
+    system_properties: Optional[List[str]] = Field(
+        default=None,
+        validation_alias=AliasChoices('system_properties', 'systemProperties'),
+        serialization_alias='systemProperties',
+        description="Non-user-facing properties managed by the Gen3 backend.",
+    )
+    unique_keys: Optional[List[List[str]]] = Field(
+        default=None,
+        validation_alias=AliasChoices('unique_keys', 'uniqueKeys'),
+        serialization_alias='uniqueKeys',
+        description="Property combinations the validator enforces as unique.",
+    )
+    required: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Explicit list of required property names. Takes precedence over per-property "
+            "'required: true' flags when both are given."
+        ),
+    )
+    namespace: Optional[str] = Field(default=None, description="Namespace override for this node.")
+    program: Optional[str] = Field(default=None, description="Program scope, '*' by default.")
+    project: Optional[str] = Field(default=None, description="Project scope, '*' by default.")
+
+    @model_validator(mode='after')
+    def check_category_present_without_extends(self):
+        """
+        A node built from scratch needs a category; one that extends a preset
+        inherits the preset's category unless it overrides it.
+
+        This is a model validator rather than a field validator because a field
+        validator does not run when the field is omitted altogether, which is
+        precisely the case being guarded against.
+        """
+        if self.category is None and self.extends is None:
+            raise ValueError(
+                "'category' is required unless the node sets 'extends' to inherit from a preset"
+            )
+        return self
 
 
 class Link(BaseModel):
     """A relationship between nodes."""
+    model_config = ConfigDict(extra='forbid')
+
     parent: str = Field(description="The parent node in the relationship.")
     multiplicity: Literal['one_to_many', 'many_to_one', 'one_to_one', 'many_to_many'] = Field(description="The cardinality of the relationship.")
     child: str = Field(description="The child node in the relationship.")
-    
-    class ConfigDict:
-        extra = 'forbid'
 
 
 class DataModel(BaseModel):
     """
     Schema to validate the data model configuration file.
     """
+    model_config = ConfigDict(extra='forbid')
+
     version: str = Field(pattern=r'^\d+\.\d+\.\d+$', description="The semantic version of the configuration file.")
     url: AnyUrl = Field(description="The URL to the data portal.")
     nodes: List[node] = Field(description="A list of data nodes (nodes) in the model.")
     links: List[Link] = Field(description="A list of relationships between nodes.")
-
-    class ConfigDict:
-        extra = 'forbid'
+    definitions: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Extra shared definitions merged into the generated _definitions.yaml, "
+            "so custom enums and refs survive regeneration."
+        ),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,18 +103,27 @@ def generated(run_cli, input_file, output_dir):
     return output_dir
 
 
-def snapshot(directory):
+@pytest.fixture
+def snapshot():
     """
-    Hash every file in a directory.
+    Return a helper that hashes every file in a directory.
 
-    Returns a {filename: sha256} mapping, so a test can assert that nothing on
-    disk moved - which is a stronger and more useful claim than asserting a
-    command merely exited non-zero.
+    Gives a {filename: sha256} mapping, so a test can assert that nothing on
+    disk moved - a stronger and more useful claim than asserting a command
+    merely exited non-zero.
+
+    This is a fixture rather than a plain importable function so the test
+    modules never need to import from `tests.conftest`. That import only
+    resolves when the repository root happens to be on sys.path, which is true
+    under `python -m pytest` but not under a bare `pytest` - the difference
+    between a suite that passes locally and one that fails in CI.
     """
-    result = {}
-    for name in sorted(os.listdir(directory)):
-        path = os.path.join(directory, name)
-        if os.path.isfile(path):
-            with open(path, "rb") as handle:
-                result[name] = hashlib.sha256(handle.read()).hexdigest()
-    return result
+    def _snapshot(directory):
+        result = {}
+        for name in sorted(os.listdir(directory)):
+            path = os.path.join(directory, name)
+            if os.path.isfile(path):
+                with open(path, "rb") as handle:
+                    result[name] = hashlib.sha256(handle.read()).hexdigest()
+        return result
+    return _snapshot

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,120 @@
+"""
+Shared fixtures for the CLI-level tests.
+
+The repository historically had no conftest.py and each test module declared its
+own fixtures. The CLI tests all need the same two things - a small valid input
+file, and a way to invoke the command-line entry point and inspect what it
+printed and returned - so they live here rather than being copied five times.
+"""
+
+import hashlib
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from gen3schemadev.cli import main
+
+
+# A deliberately small dictionary: two nodes and one link. Small enough that a
+# failure message is readable, complete enough to exercise links, enums and
+# required properties.
+MINIMAL_INPUT = """version: 0.1.0
+url: https://example.biocommons.org.au
+nodes:
+  - name: subject
+    category: clinical
+    description: "An individual organism taking part in the study."
+    properties:
+      - name: submitter_subject_id
+        description: "Submitter-assigned subject identifier."
+        type: string
+        required: true
+      - name: species
+        description: "Common name of the species."
+        type: enum
+        enums:
+          - "Human"
+          - "Mouse"
+  - name: biospecimen
+    category: biospecimen
+    description: "A sample taken from a subject."
+    properties:
+      - name: sample_type
+        description: "The kind of material sampled."
+        type: string
+links:
+  - parent: project
+    multiplicity: one_to_many
+    child: subject
+  - parent: subject
+    multiplicity: one_to_many
+    child: biospecimen
+"""
+
+
+@pytest.fixture
+def input_file(tmp_path):
+    """Write the minimal input dictionary and return its path."""
+    path = tmp_path / "input_dd.yaml"
+    path.write_text(MINIMAL_INPUT)
+    return str(path)
+
+
+@pytest.fixture
+def output_dir(tmp_path):
+    """An empty directory to generate into."""
+    path = tmp_path / "dictionary"
+    path.mkdir()
+    return str(path)
+
+
+@pytest.fixture
+def run_cli(capsys):
+    """
+    Invoke the CLI as a user would and return (exit_code, stdout).
+
+    argparse and sys.exit are what the real entry point uses, so the tests drive
+    those rather than calling internals directly - the exit code is part of the
+    contract for anyone running this in CI.
+    """
+    def _run(*args):
+        with patch.object(sys, "argv", ["gen3schemadev", *args]):
+            code = 0
+            try:
+                main()
+            except SystemExit as exc:
+                code = exc.code if exc.code is not None else 0
+        return code, capsys.readouterr().out
+    return _run
+
+
+@pytest.fixture
+def generated(run_cli, input_file, output_dir):
+    """
+    A dictionary that has already been generated once.
+
+    Most safety behaviour only becomes observable on the *second* run, so nearly
+    every test starts from here rather than from an empty directory.
+    """
+    code, _ = run_cli("generate", "-i", input_file, "-o", output_dir)
+    assert code == 0, "fixture setup: first generate should succeed"
+    return output_dir
+
+
+def snapshot(directory):
+    """
+    Hash every file in a directory.
+
+    Returns a {filename: sha256} mapping, so a test can assert that nothing on
+    disk moved - which is a stronger and more useful claim than asserting a
+    command merely exited non-zero.
+    """
+    result = {}
+    for name in sorted(os.listdir(directory)):
+        path = os.path.join(directory, name)
+        if os.path.isfile(path):
+            with open(path, "rb") as handle:
+                result[name] = hashlib.sha256(handle.read()).hexdigest()
+    return result

--- a/tests/test_cli_check_and_orphans.py
+++ b/tests/test_cli_check_and_orphans.py
@@ -16,9 +16,6 @@ case: a file nothing can regenerate, which still ships.
 import os
 import shutil
 
-from tests.conftest import snapshot
-
-
 def test_check_passes_when_output_matches_input(run_cli, input_file, generated):
     """
     Input: a dictionary freshly generated from its input, checked immediately.
@@ -35,7 +32,7 @@ def test_check_passes_when_output_matches_input(run_cli, input_file, generated):
     assert "OK" in out
 
 
-def test_check_writes_nothing(run_cli, input_file, generated):
+def test_check_writes_nothing(run_cli, input_file, generated, snapshot):
     """
     Input: a dictionary with a hand-edited file, run through --check.
 

--- a/tests/test_cli_check_and_orphans.py
+++ b/tests/test_cli_check_and_orphans.py
@@ -1,0 +1,174 @@
+"""
+Tests for drift detection (`generate --check`) and orphan reporting.
+
+Background: a dictionary repository commits both its input file and the Gen3
+YAML files generated from it. Nothing forced those two to agree, so they drifted:
+one repository committed an input file that had stopped parsing altogether and
+carried on for weeks, because the generated files were still present and looked
+fine. Another carried a node YAML that no input could produce, which continued
+to be bundled and deployed long after the input stopped describing it.
+
+`--check` regenerates in memory and compares, so continuous integration can fail
+a pull request the moment the two disagree. Orphan reporting covers the second
+case: a file nothing can regenerate, which still ships.
+"""
+
+import os
+import shutil
+
+from tests.conftest import snapshot
+
+
+def test_check_passes_when_output_matches_input(run_cli, input_file, generated):
+    """
+    Input: a dictionary freshly generated from its input, checked immediately.
+
+    Expected: exit code 0 and nothing reported.
+
+    Why it matters: this is the state continuous integration should see on a
+    healthy pull request. If a clean dictionary reported drift, the check would
+    be noise and people would rightly turn it off.
+    """
+    code, out = run_cli("generate", "-i", input_file, "-o", generated, "--check")
+
+    assert code == 0
+    assert "OK" in out
+
+
+def test_check_writes_nothing(run_cli, input_file, generated):
+    """
+    Input: a dictionary with a hand-edited file, run through --check.
+
+    Expected: the files on disk are untouched.
+
+    Why it matters: --check is meant to be safe to run anywhere, including
+    against a production dictionary and inside CI. If it repaired what it found,
+    it would be a generate with a confusing name, and running it would become a
+    decision rather than a reflex.
+    """
+    with open(f"{generated}/subject.yaml", "a") as handle:
+        handle.write("\n# hand edit\n")
+    before = snapshot(generated)
+
+    run_cli("generate", "-i", input_file, "-o", generated, "--check")
+
+    assert snapshot(generated) == before
+
+
+def test_check_detects_hand_edited_node(run_cli, input_file, generated):
+    """
+    Input: a generated dictionary where one node YAML has been edited by hand.
+
+    Expected: exit code 1, and subject.yaml named as changed.
+
+    Why it matters: a hand edit in a repository that believes it is
+    input-driven is the moment the two sources of truth part company. Catching
+    it in CI is the difference between a one-line fix now and an archaeology
+    exercise in six months.
+    """
+    with open(f"{generated}/subject.yaml", "a") as handle:
+        handle.write("\n# hand edit\n")
+
+    code, out = run_cli("generate", "-i", input_file, "-o", generated, "--check")
+
+    assert code == 1
+    assert "subject.yaml" in out
+    assert "Changed" in out
+
+
+def test_check_detects_missing_file(run_cli, input_file, generated):
+    """
+    Input: a generated dictionary with one node YAML deleted.
+
+    Expected: exit code 1, and the deleted file reported as missing.
+
+    Why it matters: a node the input describes but the dictionary lacks will not
+    be deployed, so a submission referencing it fails at the far end of the
+    pipeline. Naming it as missing points at the fix - regenerate - rather than
+    leaving someone to compare two directory listings.
+    """
+    os.remove(f"{generated}/biospecimen.yaml")
+
+    code, out = run_cli("generate", "-i", input_file, "-o", generated, "--check")
+
+    assert code == 1
+    assert "biospecimen.yaml" in out
+    assert "Missing" in out
+
+
+def test_check_detects_orphan_not_produced_by_input(run_cli, input_file, generated):
+    """
+    Input: a dictionary containing legacy_study.yaml, a node YAML that the input
+    does not describe.
+
+    Expected: exit code 1, and the file reported as orphaned.
+
+    Why it matters: this is a real incident reproduced as a test. A repository
+    carried exactly such a file for months. It could not be regenerated, so it
+    was invisible to anyone reading the input, yet it was bundled and deployed
+    like any other node. An orphan is not untidiness - it is a part of the
+    deployed model that no source describes.
+    """
+    shutil.copy(f"{generated}/subject.yaml", f"{generated}/legacy_study.yaml")
+
+    code, out = run_cli("generate", "-i", input_file, "-o", generated, "--check")
+
+    assert code == 1
+    assert "legacy_study.yaml" in out
+    assert "Orphaned" in out
+
+
+def test_orphan_is_only_a_warning_by_default(run_cli, input_file, generated):
+    """
+    Input: a dictionary containing an orphan, regenerated with --force.
+
+    Expected: the command succeeds, but the orphan is reported.
+
+    Why it matters: hand-written nodes alongside generated ones are a valid way
+    to work. The tool should say what it sees without refusing to run, because
+    for these repositories the orphan is the point, not a mistake.
+    """
+    shutil.copy(f"{generated}/subject.yaml", f"{generated}/hand_written.yaml")
+
+    code, out = run_cli("generate", "-i", input_file, "-o", generated, "--force")
+
+    assert code == 0
+    assert "hand_written.yaml" in out
+
+
+def test_orphan_is_an_error_under_input_driven(run_cli, input_file, generated):
+    """
+    Input: the same orphan, but regenerated with --input-driven.
+
+    Expected: the command fails and nothing is written.
+
+    Why it matters: --input-driven is a repository stating that its input file
+    describes the whole dictionary. A file that contradicts that claim is a
+    failure by definition, and this is what makes the declaration meaningful
+    rather than decorative.
+    """
+    shutil.copy(f"{generated}/subject.yaml", f"{generated}/hand_written.yaml")
+
+    code, out = run_cli("generate", "-i", input_file, "-o", generated, "--input-driven")
+
+    assert code == 1
+    assert "hand_written.yaml" in out
+
+
+def test_framework_files_are_never_orphans(run_cli, input_file, generated):
+    """
+    Input: a normally generated dictionary, checked as-is.
+
+    Expected: _definitions.yaml, _settings.yaml and _terms.yaml are not
+    reported as orphans.
+
+    Why it matters: those three come from packaged templates rather than from
+    the user's nodes. Flagging them would produce a warning on every healthy
+    repository, and a warning that is always present is one nobody reads.
+    """
+    code, out = run_cli("generate", "-i", input_file, "-o", generated, "--check")
+
+    assert code == 0
+    for framework_file in ("_definitions.yaml", "_settings.yaml", "_terms.yaml"):
+        assert os.path.exists(f"{generated}/{framework_file}")
+        assert f"Orphaned" not in out

--- a/tests/test_cli_generate_safety.py
+++ b/tests/test_cli_generate_safety.py
@@ -159,6 +159,45 @@ def test_only_with_unknown_node_writes_nothing_and_suggests_a_match(
     assert "did you mean" in out and "subject" in out
 
 
+def test_failed_write_leaves_output_directory_untouched(run_cli, input_file, generated):
+    """
+    Input: a regeneration in which one file partway through the alphabet cannot
+    be written, because it has been made read-only.
+
+    Expected: the command fails, every file is unchanged, and no staging
+    directory is left behind.
+
+    Why it matters: generation writes many files. Writing them one by one meant
+    a failure partway through left some updated and the rest stale - a
+    dictionary matching neither the input nor the previous commit, with nothing
+    to indicate which files were which. Building in memory does not help here,
+    because the failure happens during writing rather than generation, so files
+    are staged and moved into place only once all of them exist.
+    """
+    import os
+
+    # Change the input so every generated file would differ.
+    with open(input_file) as handle:
+        source = handle.read()
+    with open(input_file, "w") as handle:
+        handle.write(source.replace(
+            "https://example.biocommons.org.au", "https://changed.example.org"
+        ))
+
+    blocked = f"{generated}/biospecimen.yaml"
+    os.chmod(blocked, 0o400)
+    before = snapshot(generated)
+    try:
+        code, out = run_cli("generate", "-i", input_file, "-o", generated, "--force")
+    finally:
+        os.chmod(blocked, 0o600)
+
+    assert code == 1
+    assert snapshot(generated) == before
+    assert "has not been modified" in out
+    assert not [name for name in os.listdir(generated) if name.startswith(".gen3schemadev-")]
+
+
 def test_failed_generation_leaves_output_directory_untouched(
     run_cli, tmp_path, generated
 ):

--- a/tests/test_cli_generate_safety.py
+++ b/tests/test_cli_generate_safety.py
@@ -1,0 +1,193 @@
+"""
+Tests for the non-destructive behaviour of `gen3schemadev generate`.
+
+Background: a Gen3 data dictionary can be maintained in more than one way. Some
+repositories treat the input file as the source of truth and regenerate from it
+every time. Others generate once to get started and then edit the Gen3 YAML
+files directly, so the generated files become the real dictionary. Both are
+legitimate, and the tool cannot tell which one you are doing.
+
+Before this behaviour existed, `generate` simply overwrote everything it found.
+In a repository that had moved to hand-editing, a single command silently
+destroyed work, and because the generated files are large and numerous, nobody
+noticed until much later. These tests pin down the guarantee that replaced it:
+generate writes nothing over your files unless you have told it to.
+"""
+
+from tests.conftest import snapshot
+
+
+def test_first_generate_into_empty_directory_succeeds(run_cli, input_file, output_dir):
+    """
+    Input: an empty output directory and a valid input file.
+
+    Expected: generation succeeds and writes the dictionary.
+
+    Why it matters: the safety rules must not get in the way of the very first
+    run. Someone starting a new dictionary, or bootstrapping one before they
+    switch to hand-editing, should see the tool simply work.
+    """
+    code, out = run_cli("generate", "-i", input_file, "-o", output_dir)
+
+    assert code == 0
+    assert "subject.yaml" in snapshot(output_dir)
+    assert "biospecimen.yaml" in snapshot(output_dir)
+    assert "Schema generation process complete." in out
+
+
+def test_second_generate_refuses_and_leaves_every_file_byte_identical(
+    run_cli, input_file, generated
+):
+    """
+    Input: a dictionary that has already been generated, where a developer has
+    since hand-edited subject.yaml.
+
+    Expected: a second `generate` exits non-zero and every file in the directory
+    is byte-for-byte what it was beforehand, including the hand edit.
+
+    Why it matters: this is the whole safety promise. Exiting non-zero is not
+    sufficient on its own - a refusal that had already rewritten three of the
+    nineteen files would be worse than no refusal at all, because the dictionary
+    would be left in a state that matches neither the input nor the previous
+    commit. So the assertion is about the bytes on disk, not the exit code.
+    """
+    edited = f"{generated}/subject.yaml"
+    with open(edited, "a") as handle:
+        handle.write("\n# a deliberate hand edit\n")
+    before = snapshot(generated)
+
+    code, out = run_cli("generate", "-i", input_file, "-o", generated)
+
+    assert code == 1
+    assert snapshot(generated) == before
+    assert "Refusing to overwrite" in out
+
+
+def test_force_overwrites_and_discards_hand_edits(run_cli, input_file, generated):
+    """
+    Input: a generated dictionary containing a hand edit, regenerated with --force.
+
+    Expected: the command succeeds and the hand edit is gone.
+
+    Why it matters: --force is the escape hatch, and the refusal message
+    explicitly warns that it discards hand edits. That warning has to be true.
+    A --force that quietly preserved edits would be just as confusing as one
+    that destroyed them without saying so.
+    """
+    edited = f"{generated}/subject.yaml"
+    with open(edited, "a") as handle:
+        handle.write("\n# a deliberate hand edit\n")
+
+    code, _ = run_cli("generate", "-i", input_file, "-o", generated, "--force")
+
+    assert code == 0
+    assert "a deliberate hand edit" not in open(edited).read()
+
+
+def test_input_driven_regenerates_every_node(run_cli, input_file, generated):
+    """
+    Input: an already-generated dictionary, regenerated with --input-driven.
+
+    Expected: the command succeeds and overwrites without needing --force.
+
+    Why it matters: --input-driven is how a repository declares that its input
+    file is the source of truth. In that mode regeneration is the normal, safe
+    operation, so it should not require the flag that means "yes, destroy my
+    edits" - the two situations deserve different words.
+    """
+    code, _ = run_cli("generate", "-i", input_file, "-o", generated, "--input-driven")
+
+    assert code == 0
+    assert "subject.yaml" in snapshot(generated)
+
+
+def test_only_regenerates_named_node_and_leaves_hand_edits_in_others(
+    run_cli, input_file, generated
+):
+    """
+    Input: a generated dictionary where subject.yaml has been hand-edited, and
+    `--only biospecimen` is used to regenerate a different node.
+
+    Expected: biospecimen.yaml is rewritten, subject.yaml keeps its hand edit,
+    and no other file changes.
+
+    Why it matters: this is what makes the mixed workflow safe. A repository
+    that hand-maintains most of its dictionary may still want the tool to
+    regenerate one node. Without this, the only options were to overwrite
+    everything or to hand-copy files between directories, which is what several
+    repositories ended up doing.
+    """
+    edited = f"{generated}/subject.yaml"
+    with open(edited, "a") as handle:
+        handle.write("\n# a deliberate hand edit\n")
+    before = snapshot(generated)
+
+    code, _ = run_cli(
+        "generate", "-i", input_file, "-o", generated, "--only", "biospecimen"
+    )
+    after = snapshot(generated)
+
+    assert code == 0
+    assert "a deliberate hand edit" in open(edited).read()
+    assert after["subject.yaml"] == before["subject.yaml"]
+    # Every file other than the one named is untouched.
+    changed = {name for name in before if before[name] != after.get(name)}
+    assert changed <= {"biospecimen.yaml"}
+
+
+def test_only_with_unknown_node_writes_nothing_and_suggests_a_match(
+    run_cli, input_file, generated
+):
+    """
+    Input: `--only subjcet`, a misspelling of the node "subject".
+
+    Expected: the command fails, nothing on disk changes, and the message
+    suggests "subject".
+
+    Why it matters: a typo in --only could otherwise look like a successful
+    no-op, leaving someone convinced they had regenerated a node when they had
+    not. Naming the near-match turns a confusing silence into a one-second fix.
+    """
+    before = snapshot(generated)
+
+    code, out = run_cli(
+        "generate", "-i", input_file, "-o", generated, "--only", "subjcet"
+    )
+
+    assert code == 1
+    assert snapshot(generated) == before
+    assert "did you mean" in out and "subject" in out
+
+
+def test_failed_generation_leaves_output_directory_untouched(
+    run_cli, tmp_path, generated
+):
+    """
+    Input: an already-generated dictionary, regenerated with --force from an
+    input file that is malformed.
+
+    Expected: the command fails and every existing file is unchanged.
+
+    Why it matters: generation builds many files, so a failure partway through
+    could leave a dictionary that is half old and half new - the worst possible
+    state, because it is neither recoverable by regenerating nor trustworthy as
+    committed work. The implementation builds everything in memory before
+    touching disk specifically to make this impossible, and this test is what
+    holds that design in place.
+    """
+    broken = tmp_path / "broken.yaml"
+    broken.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "nodes:\n"
+        "  - name: subject\n"
+        "    category: not_a_real_category\n"
+        "    properties: []\n"
+        "links: []\n"
+    )
+    before = snapshot(generated)
+
+    code, _ = run_cli("generate", "-i", str(broken), "-o", generated, "--force")
+
+    assert code != 0
+    assert snapshot(generated) == before

--- a/tests/test_cli_generate_safety.py
+++ b/tests/test_cli_generate_safety.py
@@ -14,10 +14,7 @@ noticed until much later. These tests pin down the guarantee that replaced it:
 generate writes nothing over your files unless you have told it to.
 """
 
-from tests.conftest import snapshot
-
-
-def test_first_generate_into_empty_directory_succeeds(run_cli, input_file, output_dir):
+def test_first_generate_into_empty_directory_succeeds(run_cli, input_file, output_dir, snapshot):
     """
     Input: an empty output directory and a valid input file.
 
@@ -36,8 +33,7 @@ def test_first_generate_into_empty_directory_succeeds(run_cli, input_file, outpu
 
 
 def test_second_generate_refuses_and_leaves_every_file_byte_identical(
-    run_cli, input_file, generated
-):
+    run_cli, input_file, generated, snapshot):
     """
     Input: a dictionary that has already been generated, where a developer has
     since hand-edited subject.yaml.
@@ -84,7 +80,7 @@ def test_force_overwrites_and_discards_hand_edits(run_cli, input_file, generated
     assert "a deliberate hand edit" not in open(edited).read()
 
 
-def test_input_driven_regenerates_every_node(run_cli, input_file, generated):
+def test_input_driven_regenerates_every_node(run_cli, input_file, generated, snapshot):
     """
     Input: an already-generated dictionary, regenerated with --input-driven.
 
@@ -102,8 +98,7 @@ def test_input_driven_regenerates_every_node(run_cli, input_file, generated):
 
 
 def test_only_regenerates_named_node_and_leaves_hand_edits_in_others(
-    run_cli, input_file, generated
-):
+    run_cli, input_file, generated, snapshot):
     """
     Input: a generated dictionary where subject.yaml has been hand-edited, and
     `--only biospecimen` is used to regenerate a different node.
@@ -136,8 +131,7 @@ def test_only_regenerates_named_node_and_leaves_hand_edits_in_others(
 
 
 def test_only_with_unknown_node_writes_nothing_and_suggests_a_match(
-    run_cli, input_file, generated
-):
+    run_cli, input_file, generated, snapshot):
     """
     Input: `--only subjcet`, a misspelling of the node "subject".
 
@@ -159,7 +153,7 @@ def test_only_with_unknown_node_writes_nothing_and_suggests_a_match(
     assert "did you mean" in out and "subject" in out
 
 
-def test_failed_write_leaves_output_directory_untouched(run_cli, input_file, generated):
+def test_failed_write_leaves_output_directory_untouched(run_cli, input_file, generated, snapshot):
     """
     Input: a regeneration in which one file partway through the alphabet cannot
     be written, because it has been made read-only.
@@ -199,8 +193,7 @@ def test_failed_write_leaves_output_directory_untouched(run_cli, input_file, gen
 
 
 def test_failed_generation_leaves_output_directory_untouched(
-    run_cli, tmp_path, generated
-):
+    run_cli, tmp_path, generated, snapshot):
     """
     Input: an already-generated dictionary, regenerated with --force from an
     input file that is malformed.

--- a/tests/test_cli_messages.py
+++ b/tests/test_cli_messages.py
@@ -1,0 +1,250 @@
+"""
+Tests for the guiding messages the CLI prints when it stops or warns.
+
+Background: this tool refuses to do things. A refusal that does not explain
+itself is worse than no refusal, because the user is blocked and has nowhere to
+go except the source code. The messages are therefore treated as behaviour and
+asserted like any other output - if one regresses, someone loses a morning.
+
+Every message follows the same shape: what happened, which files are affected,
+why the tool stopped, and the concrete ways forward with destructive ones marked
+as such. The last test in this module enforces the link between code and
+documentation by checking that every doc path a message prints actually exists.
+"""
+
+import os
+import re
+
+import pytest
+
+from gen3schemadev import messages
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_refusal_names_every_file_it_would_overwrite():
+    """
+    Input: a refusal covering three named files.
+
+    Expected: all three appear in the message.
+
+    Why it matters: "some files would be overwritten" gives the reader nothing
+    to act on. Knowing exactly which files are at stake is what lets someone
+    decide in seconds whether they care - and if one of them is the file they
+    spent yesterday hand-editing, they need to see its name.
+    """
+    message = messages.overwrite_refusal(
+        "dictionary/", ["subject.yaml", "biospecimen.yaml", "project.yaml"], [], "input_dd.yaml"
+    )
+
+    assert "subject.yaml" in message
+    assert "biospecimen.yaml" in message
+    assert "project.yaml" in message
+
+
+def test_refusal_states_the_count_honestly_when_truncating():
+    """
+    Input: a refusal covering twenty files, more than the message lists inline.
+
+    Expected: the message reports twenty, and says how many were not shown.
+
+    Why it matters: a truncated list is fine, but a truncated list that hides
+    the true scale is not. Someone about to type --force is making a decision
+    about all twenty files, so the number has to be visible even when the names
+    are not.
+    """
+    names = [f"node_{i:02d}.yaml" for i in range(20)]
+
+    message = messages.overwrite_refusal("dictionary/", names, [], "input_dd.yaml")
+
+    assert "20 existing files" in message
+    assert "more)" in message
+
+
+def test_refusal_offers_every_route_forward():
+    """
+    Input: any refusal.
+
+    Expected: the message names --input-driven, --only, --force, and the option
+    of deleting the input file to work schema-first.
+
+    Why it matters: the refusal is the one place many users will ever learn that
+    these workflows exist. Leaving one out would strand whichever group of users
+    needed it - most importantly the people who bootstrapped from an input file
+    and now want to edit the YAMLs directly, who otherwise have no idea that is
+    a supported way to work.
+    """
+    message = messages.overwrite_refusal(
+        "dictionary/", ["subject.yaml"], [], "input_dd.yaml"
+    )
+
+    assert "--input-driven" in message
+    assert "--only" in message
+    assert "--force" in message
+    assert "Delete the input file" in message
+
+
+def test_refusal_marks_force_as_destructive():
+    """
+    Input: any refusal.
+
+    Expected: the --force option is described as discarding hand edits.
+
+    Why it matters: --force is the only irreversible choice on offer. It sits in
+    a list beside three safe ones, so it has to be visibly different - a reader
+    skimming for the command that makes the error go away should not be able to
+    miss that this one destroys work.
+    """
+    message = messages.overwrite_refusal(
+        "dictionary/", ["subject.yaml"], [], "input_dd.yaml"
+    )
+
+    assert "DISCARDS ANY HAND EDITS" in message
+
+
+def test_orphan_warning_states_the_consequence_not_just_the_observation():
+    """
+    Input: an orphan report for one file.
+
+    Expected: the message explains that the file still ships in the bundle and
+    reaches Gen3.
+
+    Why it matters: "orphan file found" sounds like untidiness and gets ignored.
+    The fact that matters is that an unreproducible file is still bundled and
+    still deployed, so it is part of the live data model while being invisible
+    to anyone reading the input. Stating the consequence is what turns the
+    warning into something people act on.
+    """
+    message = messages.orphan_report("dictionary/", ["legacy_study.yaml"], as_error=False)
+
+    assert "legacy_study.yaml" in message
+    assert "bundle" in message
+    assert "deployed" in message
+
+
+def test_orphan_message_differs_between_warning_and_error():
+    """
+    Input: the same orphan, reported as a warning and as an error.
+
+    Expected: only the error mentions --input-driven and calls it an error.
+
+    Why it matters: an orphan is normal in a hand-edited repository and a
+    failure in one that claims its input is complete. The same words for both
+    would either alarm the first group or under-sell the problem to the second.
+    """
+    warning = messages.orphan_report("dictionary/", ["x.yaml"], as_error=False)
+    error = messages.orphan_report("dictionary/", ["x.yaml"], as_error=True)
+
+    assert "--input-driven" in error
+    assert "error" in error
+    assert "--input-driven" not in warning
+
+
+def test_drift_report_separates_the_three_kinds_of_disagreement():
+    """
+    Input: a drift report with one changed, one missing and one orphaned file.
+
+    Expected: each is listed under its own heading and named.
+
+    Why it matters: the three mean different things and have different fixes -
+    regenerate, regenerate, and decide-then-delete respectively. Collapsing them
+    into "these files differ" would leave the reader to work out which is which.
+    """
+    message = messages.drift_report(
+        "dictionary/", ["subject.yaml"], ["biospecimen.yaml"], ["legacy.yaml"],
+        input_path="input_dd.yaml",
+    )
+
+    assert "Changed" in message and "subject.yaml" in message
+    assert "Missing" in message and "biospecimen.yaml" in message
+    assert "Orphaned" in message and "legacy.yaml" in message
+
+
+def test_unknown_only_node_suggests_a_near_match():
+    """
+    Input: --only naming "subjcet" when "subject" exists.
+
+    Expected: the message suggests "subject" and confirms nothing was written.
+
+    Why it matters: this error is almost always a typo. Suggesting the near
+    match turns a dead end into a one-second fix, and confirming that nothing
+    was written removes the worry that the tool did something partial before
+    giving up.
+    """
+    message = messages.only_unknown_nodes({"subjcet"}, ["subject", "biospecimen"])
+
+    assert "did you mean" in message
+    assert "subject" in message
+    assert "Nothing was written" in message
+
+
+def test_unparseable_input_reports_the_position_and_the_usual_cause():
+    """
+    Input: a YAML error carrying a problem mark at line 1030.
+
+    Expected: the message reports line 1031 (marks are zero-based) and explains
+    the missing-colon cause.
+
+    Why it matters: this reproduces a real incident. A repository committed a
+    node written as '- name_workflow' instead of '- name: alignment_workflow',
+    which made the input unparseable, and it went unnoticed for weeks. The raw
+    parser error - "mapping values are not allowed here" - explains nothing to
+    someone who has not seen it before, so the message names the likely cause
+    directly.
+    """
+    class FakeMark:
+        line = 1030
+        column = 10
+
+    class FakeError(Exception):
+        problem_mark = FakeMark()
+        problem = "mapping values are not allowed here"
+
+    message = messages.unparseable_input("input_dd.yaml", FakeError())
+
+    assert "line 1031" in message
+    assert "missing colon" in message
+    assert "Nothing was written" in message
+
+
+@pytest.mark.parametrize("doc_path", [
+    messages.DOCS_DICTIONARY_REPO,
+    messages.DOCS_TROUBLESHOOTING,
+])
+def test_every_message_doc_pointer_resolves_to_a_real_file(doc_path):
+    """
+    Input: each documentation path referenced by a message.
+
+    Expected: the file exists in the repository.
+
+    Why it matters: every message ends by pointing at documentation, which is
+    what keeps the messages short. If a pointer goes nowhere, the message has
+    quietly become a dead end at exactly the moment the reader needed help. This
+    test also runs in the other direction: it means documentation cannot be
+    renamed or deleted without someone noticing that a message depended on it.
+    """
+    assert os.path.exists(os.path.join(REPO_ROOT, doc_path)), (
+        f"{doc_path} is referenced by a CLI message but does not exist"
+    )
+
+
+def test_no_message_references_an_undeclared_doc_path():
+    """
+    Input: the source of the messages module.
+
+    Expected: every 'docs/...' path it mentions is one of the declared DOCS_
+    constants, which the test above proves exist.
+
+    Why it matters: the check above only covers paths routed through the
+    constants. Someone adding a message with a hardcoded doc path would slip
+    past it, so this closes the gap by reading the source directly.
+    """
+    source = open(os.path.join(REPO_ROOT, "src/gen3schemadev/messages.py")).read()
+    declared = {messages.DOCS_DICTIONARY_REPO, messages.DOCS_TROUBLESHOOTING}
+
+    referenced = set(re.findall(r"docs/[\w/]+\.md", source))
+
+    assert referenced <= declared, (
+        f"hardcoded doc paths found: {sorted(referenced - declared)}"
+    )

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -238,20 +238,34 @@ def test_create_link_prop_project():
 
 
 def test_get_properties(fixture_input_yaml_pass):
+    """
+    Input: two properties, neither of which declares any optional annotation
+    (no enums, no default, no format).
+
+    Expected: each property carries only the keys it actually set. Annotations
+    the author left unset are absent entirely rather than present-and-null.
+
+    Why it matters: a property may now declare several optional annotations
+    (default, format, items, enumDef, pattern, term). If unset ones were carried
+    through as None they would either litter the generated schema with nulls or
+    force every downstream formatter to filter them. Dropping them here, at the
+    single point where properties are read off the model, keeps that concern in
+    one place. Note this only affects the intermediate representation — the
+    formatters already discarded a null `enums`, so the generated Gen3 schema is
+    unchanged.
+    """
     result = get_properties("lipidomics_file", fixture_input_yaml_pass)
     expected = [
         {
             "cv": {
                 "type": "number",
                 "description": "Coefficient of variation (%)",
-                "enums": None,
                 "required": True
             }
         },
         {
             "lipid_species": {
                 "type": "array",
-                "enums": None,
                 "description": "List of lipid species",
                 "required": False
             }

--- a/tests/test_extends.py
+++ b/tests/test_extends.py
@@ -1,0 +1,231 @@
+"""
+Tests for `extends`, which merges a declared node onto a packaged preset.
+
+Background: Gen3 ships three nodes that its own microservices depend on -
+program, project and core_metadata_collection. Their schemas carry settings the
+simplified input language cannot express: which properties the backend manages
+rather than the submitter (project's release flags), which combination of fields
+must be unique (project's `code` rather than the usual submitter_id), default
+values for the project state machine, and ontology term identifiers on the Data
+Use consent codes.
+
+Previously a repository that wanted to add one field to `project` had to declare
+the whole node, and the generator would rebuild it from generic defaults -
+quietly dropping all of the above and breaking project release and consent
+handling. `extends` fixes that: declare only what you are adding, inherit
+everything else.
+
+The guarantee these tests protect is narrow and absolute: extending a preset
+must never remove or alter anything the preset defined.
+"""
+
+import pytest
+import yaml
+
+from gen3schemadev.schema.gen3_template import (
+    generate_project_template,
+    generate_core_metadata_template,
+)
+
+
+EXTENDS_PROJECT_INPUT = """version: 0.1.0
+url: https://example.biocommons.org.au
+nodes:
+  - name: project
+    extends: project
+    properties:
+      - name: institute_name
+        description: "Institution leading the study."
+        type: string
+      - name: ethics_approval_id
+        description: "Ethics approval identifier covering these samples."
+        type: string
+  - name: subject
+    category: clinical
+    description: "An individual organism."
+    properties:
+      - name: submitter_subject_id
+        description: "Submitter-assigned subject identifier."
+        type: string
+links:
+  - parent: project
+    multiplicity: one_to_many
+    child: subject
+"""
+
+
+@pytest.fixture
+def extended_project(run_cli, tmp_path):
+    """Generate a dictionary whose project node extends the packaged preset."""
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(EXTENDS_PROJECT_INPUT)
+    out = tmp_path / "dictionary"
+    out.mkdir()
+    code, printed = run_cli("generate", "-i", str(input_file), "-o", str(out))
+    assert code == 0, printed
+    return yaml.safe_load((out / "project.yaml").read_text()), printed
+
+
+def test_extends_project_preserves_system_properties_and_unique_keys(extended_project):
+    """
+    Input: a project node that extends the preset and adds two properties.
+
+    Expected: systemProperties and uniqueKeys are exactly the preset's.
+
+    Why it matters: project's systemProperties include the flags Gen3 uses to
+    release a project, and its uniqueKeys are keyed on `code` rather than the
+    submitter_id used by ordinary nodes. Rebuilding the node from generic
+    defaults replaces both, which breaks project release and lets duplicate
+    project codes through. This is the single most important thing extends
+    protects.
+    """
+    project, _ = extended_project
+    preset = generate_project_template()
+
+    assert project["systemProperties"] == preset["systemProperties"]
+    assert project["uniqueKeys"] == preset["uniqueKeys"]
+
+
+def test_extends_project_preserves_every_preset_property(extended_project):
+    """
+    Input: the same extended project node.
+
+    Expected: every property the preset defined is still present and unchanged.
+
+    Why it matters: the preset's consent_codes property carries Data Use
+    Ontology term identifiers, and several properties carry default values and
+    format annotations that the input language has no way to express. If any of
+    them were dropped or rewritten during the merge, the loss would be silent -
+    the generated file would still be valid, just wrong.
+    """
+    project, _ = extended_project
+    preset = generate_project_template()
+
+    for name, definition in preset["properties"].items():
+        assert name in project["properties"], f"preset property '{name}' was lost"
+        assert project["properties"][name] == definition, f"'{name}' was altered"
+
+
+def test_extends_adds_the_declared_properties(extended_project):
+    """
+    Input: a project node declaring institute_name and ethics_approval_id.
+
+    Expected: both appear in the generated schema alongside the preset's own.
+
+    Why it matters: preserving the preset is only half the job. The reason to
+    extend at all is to add fields, so the addition has to actually happen.
+    """
+    project, _ = extended_project
+
+    assert project["properties"]["institute_name"]["type"] == "string"
+    assert "ethics_approval_id" in project["properties"]
+
+
+def test_extends_reports_what_it_merged(extended_project):
+    """
+    Input: the same extended project node.
+
+    Expected: the output names the preset, and lists the added properties.
+
+    Why it matters: a merge nobody can see is a merge nobody can trust. Someone
+    reviewing a change to a Gen3-critical node needs to know at a glance what
+    was inherited and what was replaced, without diffing the result against a
+    template buried inside an installed package.
+    """
+    _, printed = extended_project
+
+    assert "extends the packaged 'project' preset" in printed
+    assert "institute_name" in printed
+    assert "inherited" in printed
+
+
+def test_declared_core_metadata_collection_is_no_longer_silently_discarded(
+    run_cli, tmp_path
+):
+    """
+    Input: a core_metadata_collection node that extends its preset and adds
+    submitter_cmc_id.
+
+    Expected: submitter_cmc_id is present in the generated schema.
+
+    Why it matters: this is a regression test for a real bug. program and
+    project were only written from their templates when the user had not
+    declared them, but core_metadata_collection was written unconditionally,
+    after the user's version had already been generated. The result was that a
+    declared core_metadata_collection was built and then immediately overwritten
+    - one production dictionary declared submitter_cmc_id for months while the
+    generated dictionary never contained it, and nothing reported a problem.
+    """
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "nodes:\n"
+        "  - name: core_metadata_collection\n"
+        "    extends: core_metadata_collection\n"
+        "    properties:\n"
+        "      - name: submitter_cmc_id\n"
+        "        description: \"Submitter-assigned identifier.\"\n"
+        "        type: string\n"
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    description: \"An individual organism.\"\n"
+        "    properties: []\n"
+        "links:\n"
+        "  - parent: project\n"
+        "    multiplicity: one_to_many\n"
+        "    child: subject\n"
+    )
+    out = tmp_path / "dictionary"
+    out.mkdir()
+
+    code, _ = run_cli("generate", "-i", str(input_file), "-o", str(out))
+    cmc = yaml.safe_load((out / "core_metadata_collection.yaml").read_text())
+
+    assert code == 0
+    assert "submitter_cmc_id" in cmc["properties"]
+    # and the preset's own properties are still intact
+    preset = generate_core_metadata_template()
+    for name in preset["properties"]:
+        assert name in cmc["properties"]
+
+
+def test_extends_allows_an_explicit_override(run_cli, tmp_path):
+    """
+    Input: a project node that extends the preset but sets submittable: false.
+
+    Expected: the generated schema uses false, not the preset's true.
+
+    Why it matters: inheriting by default only works if deliberate overrides are
+    still possible. The rule is that anything written in the input wins and
+    anything omitted is inherited, so an author is never stuck with a preset
+    value they need to change.
+    """
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "nodes:\n"
+        "  - name: project\n"
+        "    extends: project\n"
+        "    submittable: false\n"
+        "    properties: []\n"
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    description: \"An individual organism.\"\n"
+        "    properties: []\n"
+        "links:\n"
+        "  - parent: project\n"
+        "    multiplicity: one_to_many\n"
+        "    child: subject\n"
+    )
+    out = tmp_path / "dictionary"
+    out.mkdir()
+
+    code, printed = run_cli("generate", "-i", str(input_file), "-o", str(out))
+    project = yaml.safe_load((out / "project.yaml").read_text())
+
+    assert code == 0
+    assert generate_project_template()["submittable"] is True
+    assert project["submittable"] is False
+    assert "overrode" in printed

--- a/tests/test_extends.py
+++ b/tests/test_extends.py
@@ -190,6 +190,99 @@ def test_declared_core_metadata_collection_is_no_longer_silently_discarded(
         assert name in cmc["properties"]
 
 
+def test_a_preset_named_node_merges_even_without_extends(run_cli, tmp_path):
+    """
+    Input: a core_metadata_collection node declared with a category and one
+    extra property, but WITHOUT saying `extends`.
+
+    Expected: the preset's own properties all survive, the extra property is
+    added, and the output explains that the node was merged rather than
+    replaced.
+
+    Why it matters: this is the most dangerous case, and a real repository is in
+    it. Declaring a node that happens to share a preset's name reads like
+    "add this field", not "replace the entire node", but building it from
+    generic defaults drops all fourteen of the preset's properties. The
+    resulting file is still valid YAML and still passes validation, so the loss
+    is completely silent. Merging by default is the safe reading of the author's
+    intent, and the message tells them how to make it explicit.
+    """
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "nodes:\n"
+        "  - name: core_metadata_collection\n"
+        "    category: administrative\n"
+        "    description: \"Core metadata for this commons.\"\n"
+        "    properties:\n"
+        "      - name: submitter_cmc_id\n"
+        "        description: \"Submitter-assigned identifier.\"\n"
+        "        type: string\n"
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    description: \"An individual organism.\"\n"
+        "    properties: []\n"
+        "links:\n"
+        "  - parent: project\n"
+        "    multiplicity: one_to_many\n"
+        "    child: subject\n"
+    )
+    out = tmp_path / "dictionary"
+    out.mkdir()
+
+    code, printed = run_cli("generate", "-i", str(input_file), "-o", str(out))
+    cmc = yaml.safe_load((out / "core_metadata_collection.yaml").read_text())
+
+    assert code == 0
+    for name in generate_core_metadata_template()["properties"]:
+        assert name in cmc["properties"], f"preset property '{name}' was lost"
+    assert "submitter_cmc_id" in cmc["properties"]
+    assert "shares the name of a packaged preset" in printed
+
+
+def test_a_declared_category_is_written_as_a_plain_string(run_cli, tmp_path):
+    """
+    Input: a preset-named node that declares `category: administrative`.
+
+    Expected: generation succeeds and the category is the string
+    "administrative".
+
+    Why it matters: the category is validated into an enum member, and an enum
+    member cannot be serialised to YAML. Passing it through the merge unchanged
+    made generation fail at the final write with a representer error naming an
+    internal Python type - an error that gives the author no clue that their
+    perfectly reasonable `category:` line was responsible.
+    """
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "nodes:\n"
+        "  - name: project\n"
+        "    extends: project\n"
+        "    category: administrative\n"
+        "    properties: []\n"
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    description: \"An individual organism.\"\n"
+        "    properties: []\n"
+        "links:\n"
+        "  - parent: project\n"
+        "    multiplicity: one_to_many\n"
+        "    child: subject\n"
+    )
+    out = tmp_path / "dictionary"
+    out.mkdir()
+
+    code, _ = run_cli("generate", "-i", str(input_file), "-o", str(out))
+    project = yaml.safe_load((out / "project.yaml").read_text())
+
+    assert code == 0
+    assert project["category"] == "administrative"
+    assert isinstance(project["category"], str)
+
+
 def test_extends_allows_an_explicit_override(run_cli, tmp_path):
     """
     Input: a project node that extends the preset but sets submittable: false.

--- a/tests/test_input_model.py
+++ b/tests/test_input_model.py
@@ -1,0 +1,316 @@
+"""
+Tests for the widened input model: node-level settings and property annotations.
+
+Background: the input language originally described a property with five fields
+and a node with four. Anything Gen3 supported beyond that - a default value, a
+format annotation, the list of properties the backend manages - could only be
+obtained by hand-editing the generated file afterwards, which put the repository
+back in the position of not being able to regenerate.
+
+These tests cover what the input can now express, and the two rules that keep
+the widening safe: omitting a field inherits the template default rather than
+writing a null over it, and an unrecognised key is an error rather than a
+silently ignored typo.
+"""
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from gen3schemadev.schema.input_schema import DataModel, node, Property
+
+
+def _model(nodes_yaml):
+    """Validate a small data model containing the given nodes block."""
+    return DataModel.model_validate(yaml.safe_load(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        f"nodes:\n{nodes_yaml}"
+        "links:\n"
+        "  - parent: project\n"
+        "    multiplicity: one_to_many\n"
+        "    child: subject\n"
+    ))
+
+
+def test_property_default_and_format_reach_the_output(run_cli, tmp_path):
+    """
+    Input: a property declaring both a default value and a format annotation.
+
+    Expected: both appear verbatim in the generated schema.
+
+    Why it matters: Gen3's own project node relies on defaults for its state
+    machine and on a date-time format for its release date. Until the input
+    could express these, any repository needing them had to edit the generated
+    file by hand and then never regenerate.
+    """
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "nodes:\n"
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    description: \"An individual organism.\"\n"
+        "    properties:\n"
+        "      - name: release_state\n"
+        "        description: \"Whether the record has been released.\"\n"
+        "        type: string\n"
+        "        default: unreleased\n"
+        "      - name: released_at\n"
+        "        description: \"When the record was released.\"\n"
+        "        type: string\n"
+        "        format: date-time\n"
+        "links: []\n"
+    )
+    out = tmp_path / "dictionary"
+    out.mkdir()
+
+    code, _ = run_cli("generate", "-i", str(input_file), "-o", str(out))
+    subject = yaml.safe_load((out / "subject.yaml").read_text())
+
+    assert code == 0
+    assert subject["properties"]["release_state"]["default"] == "unreleased"
+    assert subject["properties"]["released_at"]["format"] == "date-time"
+
+
+def test_unset_annotations_are_absent_rather_than_null(run_cli, tmp_path):
+    """
+    Input: a plain string property declaring none of the optional annotations.
+
+    Expected: the generated property has no 'default', 'format' or 'pattern'
+    keys at all.
+
+    Why it matters: the model now offers half a dozen optional annotations. If
+    every unset one were emitted as null, each property in every schema would
+    carry a row of meaningless nulls, and the Gen3 metaschema rejects a null
+    where it expects a string. Absent and null are not the same thing here.
+    """
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "nodes:\n"
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    description: \"An individual organism.\"\n"
+        "    properties:\n"
+        "      - name: plain_field\n"
+        "        description: \"Nothing special.\"\n"
+        "        type: string\n"
+        "links: []\n"
+    )
+    out = tmp_path / "dictionary"
+    out.mkdir()
+
+    run_cli("generate", "-i", str(input_file), "-o", str(out))
+    prop = yaml.safe_load((out / "subject.yaml").read_text())["properties"]["plain_field"]
+
+    assert prop == {"type": "string", "description": "Nothing special."}
+
+
+def test_node_level_settings_accept_both_spellings():
+    """
+    Input: one node using snake_case 'system_properties' and another using the
+    Gen3 spelling 'systemProperties'.
+
+    Expected: both validate and carry the same value.
+
+    Why it matters: the rest of the input file is snake_case, but the generated
+    Gen3 schema is camelCase, and people copy fragments from existing schemas
+    when authoring. Accepting either spelling avoids a class of error whose
+    message would otherwise be an unhelpful "unknown field".
+    """
+    model = _model(
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    system_properties: [id, state]\n"
+        "    properties: []\n"
+        "  - name: biospecimen\n"
+        "    category: biospecimen\n"
+        "    systemProperties: [id, state]\n"
+        "    properties: []\n"
+    )
+
+    assert model.nodes[0].system_properties == ["id", "state"]
+    assert model.nodes[1].system_properties == ["id", "state"]
+
+
+def test_unset_node_fields_do_not_overwrite_template_defaults(run_cli, tmp_path):
+    """
+    Input: a node that declares no systemProperties or uniqueKeys.
+
+    Expected: the generated schema still carries the standard Gen3 defaults.
+
+    Why it matters: making these fields optional is only safe if leaving one out
+    means "inherit". If an unset field were written through as null, every node
+    in every existing dictionary would lose its systemProperties on the next
+    regeneration - a silent, catastrophic change that still produces a file that
+    looks plausible.
+    """
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "nodes:\n"
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    description: \"An individual organism.\"\n"
+        "    properties: []\n"
+        "links: []\n"
+    )
+    out = tmp_path / "dictionary"
+    out.mkdir()
+
+    run_cli("generate", "-i", str(input_file), "-o", str(out))
+    subject = yaml.safe_load((out / "subject.yaml").read_text())
+
+    assert subject["systemProperties"] == [
+        "id", "project_id", "state", "created_datetime", "updated_datetime"
+    ]
+    assert subject["uniqueKeys"] == [["id"], ["project_id", "submitter_id"]]
+
+
+def test_node_level_required_takes_precedence_over_property_flags(run_cli, tmp_path):
+    """
+    Input: a node declaring `required: [alpha]` while a different property,
+    beta, carries `required: true`.
+
+    Expected: the generated required list is driven by the node-level
+    declaration, and always includes submitter_id and type.
+
+    Why it matters: two ways of saying the same thing need a stated winner,
+    otherwise the result depends on implementation order and changes without
+    warning. The explicit node-level list is the more specific instruction, so
+    it wins.
+    """
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "nodes:\n"
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    description: \"An individual organism.\"\n"
+        "    required: [alpha]\n"
+        "    properties:\n"
+        "      - name: alpha\n"
+        "        description: \"First field.\"\n"
+        "        type: string\n"
+        "      - name: beta\n"
+        "        description: \"Second field.\"\n"
+        "        type: string\n"
+        "        required: true\n"
+        "links: []\n"
+    )
+    out = tmp_path / "dictionary"
+    out.mkdir()
+
+    run_cli("generate", "-i", str(input_file), "-o", str(out))
+    subject = yaml.safe_load((out / "subject.yaml").read_text())
+
+    assert subject["required"] == ["alpha", "submitter_id", "type"]
+
+
+def test_unknown_key_in_input_is_rejected(run_cli, tmp_path):
+    """
+    Input: a property using the misspelling 'descriptoin'.
+
+    Expected: generation fails, names the offending location, and writes nothing.
+
+    Why it matters: unknown keys used to be dropped in silence, so a typo in a
+    field name produced a schema quietly missing that field. Since a description
+    is mandatory in Gen3, the failure would surface much later as a metaschema
+    error against a file nobody remembered editing.
+    """
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "nodes:\n"
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    description: \"An individual organism.\"\n"
+        "    properties:\n"
+        "      - name: species\n"
+        "        descriptoin: \"Typo above.\"\n"
+        "        type: string\n"
+        "links: []\n"
+    )
+    out = tmp_path / "dictionary"
+    out.mkdir()
+
+    code, printed = run_cli("generate", "-i", str(input_file), "-o", str(out))
+
+    assert code == 1
+    assert "descriptoin" in printed or "description" in printed
+    assert list(out.iterdir()) == []
+
+
+def test_category_is_required_unless_the_node_extends_a_preset():
+    """
+    Input: one node with neither category nor extends, and one with extends but
+    no category.
+
+    Expected: the first is rejected; the second is accepted.
+
+    Why it matters: category was mandatory, and it must stay mandatory for
+    ordinary nodes because it drives how the node is generated. A node that
+    extends a preset is the one legitimate exception, since it inherits the
+    preset's category - requiring it there would force authors to restate a
+    value they are not choosing.
+    """
+    with pytest.raises(ValidationError):
+        _model(
+            "  - name: subject\n"
+            "    properties: []\n"
+        )
+
+    model = _model(
+        "  - name: project\n"
+        "    extends: project\n"
+        "    properties: []\n"
+    )
+    assert model.nodes[0].category is None
+    assert model.nodes[0].extends == "project"
+
+
+def test_extra_definitions_are_merged_into_the_generated_definitions(run_cli, tmp_path):
+    """
+    Input: a top-level `definitions` block contributing a custom enum.
+
+    Expected: the custom enum appears in the generated _definitions.yaml, and
+    the packaged definitions are still present.
+
+    Why it matters: _definitions.yaml is rewritten from a packaged template on
+    every run, so any shared enum a repository added by hand was destroyed the
+    next time anyone regenerated. One repository maintained a bespoke script
+    purely to re-inject its enums after every generation; declaring them in the
+    input removes the need for that entirely.
+    """
+    input_file = tmp_path / "input_dd.yaml"
+    input_file.write_text(
+        "version: 0.1.0\n"
+        "url: https://example.biocommons.org.au\n"
+        "definitions:\n"
+        "  enum_sample_state:\n"
+        "    description: \"Whether a sample is available.\"\n"
+        "    enum: [available, exhausted]\n"
+        "nodes:\n"
+        "  - name: subject\n"
+        "    category: clinical\n"
+        "    description: \"An individual organism.\"\n"
+        "    properties: []\n"
+        "links: []\n"
+    )
+    out = tmp_path / "dictionary"
+    out.mkdir()
+
+    code, _ = run_cli("generate", "-i", str(input_file), "-o", str(out))
+    definitions = yaml.safe_load((out / "_definitions.yaml").read_text())
+
+    assert code == 0
+    assert definitions["enum_sample_state"]["enum"] == ["available", "exhausted"]
+    # the packaged definitions survive the merge
+    assert "ubiquitous_properties" in definitions
+    assert "datetime" in definitions


### PR DESCRIPTION
Targets **3.0.0**. `generate` changes its default behaviour and the input model now rejects unknown
keys, so this is a major bump.

## Why

Four repositories use this tool and each invented its own workflow, because the tool has never had
an opinion about where the source of truth lives. The evidence across them:

| Repo | Actual mode | `input_dd.yaml` |
| --- | --- | --- |
| bpsych-gen3-schemadev | input-driven | authoritative |
| acdc-schema-json | hybrid — hand-edits `prod_dict` | partial scaffold |
| omix3schemadev | hybrid, drifting | **unparseable since 2026-07-06** |
| nci_1000g_gen3schemadev | schema-first | none |

`omix3schemadev` committed `- name_workflow` instead of `- name: alignment_workflow`. Generation has
been impossible on its `main` for weeks and nobody noticed, because nothing verified that the input
still produced the committed output.

## What changes

**`generate` no longer overwrites by default.** An empty output directory still just works. Where
files already exist it stops and explains four ways forward: `--input-driven`, `--only <node>`,
deleting the input to work schema-first, or `--force`. Only `--force` discards hand edits, and the
message says so.

**`--check`** regenerates in memory, compares, writes nothing, exits non-zero on drift. This is the
CI gate — and the thing that catches the omix3 class of failure immediately.

**Orphan reporting** for files the input cannot produce. These still ship in the bundle and reach
Gen3, which is how one repository kept deploying a node no source described.

**`extends`** merges a node onto the packaged `program` / `project` / `core_metadata_collection`
presets, so properties can be added without losing the node-level settings Gen3 depends on —
`project`'s release-related `systemProperties`, its `uniqueKeys` on `code`, the DUO `enumDef` terms
on `consent_codes`. A node sharing a preset's name merges by default, since replacing it silently
loses those and still produces a file that validates.

**Wider input model** — node-level `systemProperties`/`uniqueKeys`/`required`/`submittable`, and
property-level `default`, `format`, `items`, `enumDef`, `pattern`, `term`. Repo-supplied
`definitions` are merged into `_definitions.yaml` rather than being clobbered every run.

**Fixes** `core_metadata_collection` being written unconditionally over a user-declared version;
unparseable and invalid input now produce guided errors rather than tracebacks; `validate` with no
target reports usage instead of raising `NameError`; writes are staged and moved into place so a
failure cannot leave the dictionary half-updated.

## Documentation

New: [Running a Gen3 Dictionary Repository](docs/gen3schemadev/dictionary_repo.md) — the three
workflows, where the source of truth sits in each, layout, CI, versioning, and the
bundled-filename deployment contract.

Updated because the behaviour they describe changed: `quickstart.md` (its second run now hits the
refusal), `first_dictionary.md`, `troubleshooting.md` (five new failure modes in its existing
Error/Cause/Fix format), `README.md`, `setup.md`. Also repoints seven dead links and fixes two more.

## Verification

160 tests pass, 44 of them new across five files. The repo had **no end-to-end CLI test at all**
before this, and every change here is CLI-level.

Beyond the suite, I exercised the built tool by hand — all against throwaway copies, never the real
repos. That pass found four bugs the tests I had written did not:

- `--only` was hitting the overwrite refusal, making the flag useless
- `--check` compared parsed YAML, so a hand-added comment — a real edit regeneration destroys — went
  undetected
- a declared `category` reached the YAML writer as an enum and crashed generation
- a preset-named node without `extends` stripped all 14 Dublin Core properties from
  `core_metadata_collection`

Each is now fixed and pinned by a regression test.

Replaying all four consumer repos: bpsych differs only by the upstream 2.5.0 datetime-description
fix plus its now-working `submitter_cmc_id`; omix3 fails loudly naming line 1031; acdc reports the
drift from its hand-edited `prod_dict`; nci_1000g validates as schema-first. None crashed.

## Not included

`bundle` cannot report orphans — it receives only a directory, so it has no input to compare
against. Orphan detection lives in `generate` and `--check`, which do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)