### PR TITLE
feat: allow links to declare whether they are required

### DIFF
--- a/docs/gen3_data_modelling/links.md
+++ b/docs/gen3_data_modelling/links.md
@@ -92,3 +92,83 @@ links:
         required: false
 ```
 In this setup, the subgroup has `required: true` and `exclusive: false`. This means a `lipidomics_file` must be linked to at least one of the nodes in the group, and it can be linked to more than one. It can be linked to a `sample`, a `core_metadata_collection`, or both. While the individual links inside the group are optional (`required: false`), the subgroup's top-level rule ensures the node is never left orphaned.
+
+
+***
+
+
+# Declaring Links in the `input_yaml`
+
+Everything above describes a `Gen3 Schema` as it is written out. If you are working from an `input_yaml`, you do not write those blocks yourself — you declare links as a flat list at the bottom of the file and Gen3SchemaDev builds them.
+
+Each entry reads as *"one `parent` is linked to `multiplicity` `child`"*:
+
+```yaml
+links:
+  - parent: sample
+    multiplicity: one_to_many
+    child: lipidomics_file
+```
+
+Gen3SchemaDev derives the rest: `name` from the parent, `backref` from the child, `label: part_of`, and the multiplicity inverted so that it reads from the child's point of view.
+
+## Making a link optional
+
+Add `required` to say whether an instance of the child *must* be attached to a parent of that type. It defaults to `true`, so leaving it out gives the same result as before this option existed.
+
+```yaml
+links:
+  # Every lipidomics file must belong to a sample.
+  - parent: sample
+    multiplicity: one_to_many
+    child: lipidomics_file
+
+  # A file may record the site it came from, but does not have to.
+  - parent: site
+    multiplicity: one_to_many
+    child: lipidomics_file
+    required: false
+```
+
+- *Note: `required` is set per link, not per node. Where a node has several parents, each link is answered independently — the second and third links can disagree with the first.*
+
+## A node with several parents
+
+When a node is the child of more than one link, Gen3SchemaDev collects them into a single subgroup for you. You do not write the subgroup; you write one entry per parent, and each keeps its own `required` value:
+
+```yaml
+links:
+  - parent: sample
+    multiplicity: one_to_many
+    child: lipidomics_file
+    required: true
+  - parent: lipidomics_assay
+    multiplicity: one_to_many
+    child: lipidomics_file
+    required: true
+  - parent: site
+    multiplicity: one_to_many
+    child: lipidomics_file
+    required: false
+```
+
+This generates a subgroup of three links carrying `true`, `true` and `false` respectively.
+
+## How the two levels of `required` interact
+
+A generated subgroup has two different `required` flags, and they answer different questions:
+
+| Where | Question it answers | Settable from the `input_yaml`? |
+| :--- | :--- | :--- |
+| On an individual link | Must *this particular* parent be supplied? | Yes — `required` on the link |
+| On the subgroup | Must *at least one* parent from the group be supplied? | No — always `true` |
+
+So a node whose links are all `required: false` is still never left orphaned: the subgroup rule means at least one parent must be present, while leaving the submitter free to choose which. That combination is the usual shape for a file node that can hang off any one of several parents.
+
+- *Note: the subgroup's own `exclusive` and `required` flags cannot currently be set from the `input_yaml` — they are always `false` and `true`. If you need `exclusive: true`, the schema must be edited by hand.*
+
+## Links involving `program`, `project` and `core_metadata_collection`
+
+These three nodes come from Gen3SchemaDev's own packaged templates, complete with their links. A link you declare whose `child` is one of them is **discarded**, and setting `required` on it has no effect.
+
+The link from a `data_file` node *to* `core_metadata_collection` is the opposite case: it is added for you, always with `required: false`, whether or not that node declares any links of its own.

--- a/docs/gen3schemadev/first_dictionary.md
+++ b/docs/gen3schemadev/first_dictionary.md
@@ -345,6 +345,22 @@ In the example above (parent node perspective):
 - many `sample` data records can be linked to one `assay`.
 - many `sample` data records can be linked to one `lipidomics_file`.
 
+### 4.3 Making a link optional
+By default every link is required, meaning a record cannot be submitted without it. Add `required: false` when a parent is optional.
+```yaml
+links:
+    - parent: sample
+      multiplicity: many_to_one
+      child: lipidomics_file
+    - parent: site
+      multiplicity: many_to_one
+      child: lipidomics_file
+      required: false
+```
+- Here a `lipidomics_file` must belong to a `sample`, but recording the `site` it came from is optional.
+- `required` is set per link, so where a node has two or three parents, each one is answered independently.
+- *For how this interacts with subgroups, and what happens for `program`, `project` and `core_metadata_collection`, see [Defining Links in Gen3](../gen3_data_modelling/links.md#declaring-links-in-the-inputyaml).*
+
 
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Gen3SchemaDev"
-version = "3.0.1"
+version = "3.1.0"
 description = "Tool for data modelling in Gen3"
 authors = [
     {name = "JoshuaHarris391",email = "harjo391@gmail.com"}

--- a/src/gen3schemadev/converter.py
+++ b/src/gen3schemadev/converter.py
@@ -223,7 +223,8 @@ def convert_node_links(links: list[dict], required: bool = True) -> list[dict]:
 
     Args:
         links: A list of link dictionaries for the node.
-        required: Whether the links are required (default: True).
+        required: Fallback used for links that do not declare their own value
+            (default: True).
 
     Returns:
         A list of formatted link dictionaries for the Gen3 schema.
@@ -236,7 +237,10 @@ def convert_node_links(links: list[dict], required: bool = True) -> list[dict]:
             label="part_of",
             target_type=link['parent'],
             multiplicity=flip_multiplicity(link['multiplicity']),
-            required=required
+            # Each link carries its own value, so the second and third links of
+            # a multi-link node can differ. The parameter remains as a fallback
+            # for callers passing raw dicts that predate the input field.
+            required=link.get('required', required)
         )
         link_list.append(link_obj.to_dict())
 
@@ -801,9 +805,13 @@ def populate_template(node_name: str, input_data: DataSourceProtocol, template: 
     links = get_node_links(node_name, input_data)
     converted_links = convert_node_links(links)
     
-    # Add core metadata link for file nodes
-    if file_node and links:
-        converted_links = add_core_metadata_link(converted_links, links[0]['child'])
+    # Add core metadata link for file nodes. This is not conditional on the node
+    # having declared links of its own: Gen3 requires every data_file node to
+    # link to core_metadata_collection, and construct_props adds the matching
+    # property unconditionally. Skipping the link for a link-less data_file node
+    # produced a schema that failed this tool's own validation rule.
+    if file_node:
+        converted_links = add_core_metadata_link(converted_links, node_name)
     
     # Create link group if multiple links exist
     if len(converted_links) > 1:

--- a/src/gen3schemadev/schema/input_schema.py
+++ b/src/gen3schemadev/schema/input_schema.py
@@ -170,6 +170,14 @@ class Link(BaseModel):
     parent: str = Field(description="The parent node in the relationship.")
     multiplicity: Literal['one_to_many', 'many_to_one', 'one_to_one', 'many_to_many'] = Field(description="The cardinality of the relationship.")
     child: str = Field(description="The child node in the relationship.")
+    required: bool = Field(
+        default=True,
+        description=(
+            "Whether every instance of the child must be linked to a parent of this type. "
+            "Defaults to True, which is what the generator emitted before this was declarable, "
+            "so leaving it out changes nothing."
+        ),
+    )
 
 
 class DataModel(BaseModel):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -35,9 +35,27 @@ def test_get_node_data_not_found(fixture_input_yaml_pass):
 
 
 def test_get_node_links(fixture_input_yaml_pass):
+    """
+    Input: a node that is the child of two declared links, where neither link
+    declares `required`.
+
+    Expected: both links are returned, and each carries `required: True` from
+    the model default.
+
+    Why it matters: links are read straight off the validated model, so a link
+    now arrives with its own `required` value rather than having one stamped on
+    later. The default is True because that is what the generator emitted before
+    the field was declarable — which is what keeps every existing dictionary
+    regenerating unchanged.
+    """
     links = get_node_links('lipidomics_file', fixture_input_yaml_pass)
     assert len(links) == 2
-    assert dict(links[0]) == {'parent': 'sample', 'multiplicity': 'one_to_many', 'child': 'lipidomics_file'}
+    assert dict(links[0]) == {
+        'parent': 'sample',
+        'multiplicity': 'one_to_many',
+        'child': 'lipidomics_file',
+        'required': True,
+    }
 
 
 

--- a/tests/test_link_required.py
+++ b/tests/test_link_required.py
@@ -1,0 +1,332 @@
+"""
+Tests for declaring whether a link is required, per link.
+
+Background: in Gen3, every link on a node carries a `required` flag saying
+whether an instance of the child must be attached to a parent of that type.
+Until now the input language could not express it — a link was declared as a
+plain parent/multiplicity/child triple and the generator stamped
+`required: true` on every one.
+
+That is not a cosmetic gap. Across the four dictionaries built with this tool,
+41 of 113 declared links are `required: false`, and the same triple shape appears
+with both values: in one repository `subject -> site` is required while
+`subject -> demographic_measurements`, an identical one_to_one triple, is
+optional. No rule derived from the triple could produce both, so those values had
+been hand-edited into the generated files and were destroyed on regeneration.
+
+A node with several links matters here too. Where a node has two or three
+parents the generator emits them as one subgroup, and each member needs its own
+answer — typically a real parent that is required alongside an optional
+attachment. These tests pin that each link keeps its own value rather than the
+node getting a single blanket setting.
+"""
+
+import textwrap
+
+import pytest
+import yaml
+
+from gen3schemadev.converter import convert_node_links, get_node_links, populate_template
+from gen3schemadev.schema.gen3_template import generate_gen3_template, get_metaschema
+from gen3schemadev.schema.input_schema import DataModel
+
+
+def build(input_yaml):
+    """Validate an input document and return (model, node template)."""
+    model = DataModel.model_validate(yaml.safe_load(textwrap.dedent(input_yaml)))
+    return model, generate_gen3_template(get_metaschema())
+
+
+def links_of(schema):
+    """Return a node's links, flattening the subgroup wrapper if present."""
+    links = schema.get('links') or []
+    if links and 'subgroup' in links[0]:
+        return links[0]['subgroup']
+    return links
+
+
+def required_by_name(schema):
+    """Map link name -> required flag, for readable assertions."""
+    return {link['name']: link['required'] for link in links_of(schema)}
+
+
+BASE = """
+    version: 0.1.0
+    url: https://example.biocommons.org.au
+    nodes:
+      - name: subject
+        category: clinical
+        description: "An individual organism."
+        properties: []
+      - name: site
+        category: clinical
+        description: "A collection site."
+        properties: []
+      - name: measurement
+        category: clinical
+        description: "A measurement taken from a subject."
+        properties: []
+    links:
+      - parent: project
+        multiplicity: one_to_many
+        child: subject
+      - parent: subject
+        multiplicity: one_to_many
+        child: measurement
+"""
+
+
+def test_link_is_required_by_default():
+    """
+    Input: a link that says nothing about `required`.
+
+    Expected: the generated link is `required: true`.
+
+    Why it matters: this is what makes the feature additive. Every dictionary
+    written before `required` was declarable must regenerate byte-identically,
+    so the default has to match the value the generator used to hardcode. A
+    different default would silently flip every link in four production models.
+    """
+    model, template = build(BASE)
+
+    schema = populate_template('measurement', model, template)
+
+    assert required_by_name(schema) == {'subjects': True}
+
+
+def test_link_can_be_declared_optional():
+    """
+    Input: the same link, declared `required: false`.
+
+    Expected: the generated link is `required: false`.
+
+    Why it matters: this is the whole point. One repository has eight links that
+    are optional in its committed dictionary and could not be expressed at all,
+    so regenerating would have quietly made eight parent relationships mandatory
+    and broken submissions that omit them.
+    """
+    model, template = build(BASE.replace(
+        "      - parent: subject\n        multiplicity: one_to_many\n        child: measurement\n",
+        "      - parent: subject\n        multiplicity: one_to_many\n        child: measurement\n        required: false\n",
+    ))
+
+    schema = populate_template('measurement', model, template)
+
+    assert required_by_name(schema) == {'subjects': False}
+
+
+def test_each_link_in_a_subgroup_keeps_its_own_required():
+    """
+    Input: a node with three parents — the first required, the second optional,
+    the third required.
+
+    Expected: the generated subgroup carries true, false, true respectively.
+
+    Why it matters: this is the headline case. A node with several parents is
+    emitted as one subgroup, and previously every member got the same flag. Real
+    dictionaries need to mix them — a file node genuinely belongs to its assay
+    but only optionally to a collection site — so the second and third links must
+    be able to disagree with the first.
+    """
+    model, template = build("""
+        version: 0.1.0
+        url: https://example.biocommons.org.au
+        nodes:
+          - name: subject
+            category: clinical
+            description: "An individual organism."
+            properties: []
+          - name: site
+            category: clinical
+            description: "A collection site."
+            properties: []
+          - name: assay
+            category: biospecimen
+            description: "An assay."
+            properties: []
+          - name: measurement
+            category: clinical
+            description: "A measurement."
+            properties: []
+        links:
+          - parent: project
+            multiplicity: one_to_many
+            child: subject
+          - parent: subject
+            multiplicity: one_to_many
+            child: measurement
+            required: true
+          - parent: site
+            multiplicity: one_to_many
+            child: measurement
+            required: false
+          - parent: assay
+            multiplicity: one_to_many
+            child: measurement
+            required: true
+    """)
+
+    schema = populate_template('measurement', model, template)
+
+    assert required_by_name(schema) == {
+        'subjects': True,
+        'sites': False,
+        'assays': True,
+    }
+    # The subgroup wrapper itself is unchanged - "at least one of these".
+    assert schema['links'][0]['exclusive'] is False
+    assert schema['links'][0]['required'] is True
+
+
+def test_single_link_node_keeps_its_required():
+    """
+    Input: a node with exactly one parent, declared optional.
+
+    Expected: the flat, non-subgroup link form is `required: false`.
+
+    Why it matters: a node with one link is emitted as a bare list rather than a
+    subgroup, which is a separate code path. The eight links that motivated this
+    feature are all of this shape, so if only the subgroup path honoured the
+    flag the feature would miss its own use case.
+    """
+    model, template = build(BASE.replace(
+        "      - parent: subject\n        multiplicity: one_to_many\n        child: measurement\n",
+        "      - parent: subject\n        multiplicity: one_to_many\n        child: measurement\n        required: false\n",
+    ))
+
+    schema = populate_template('measurement', model, template)
+
+    assert 'subgroup' not in schema['links'][0]
+    assert schema['links'][0]['required'] is False
+
+
+def test_injected_core_metadata_link_stays_optional():
+    """
+    Input: a data_file node whose declared link is marked required.
+
+    Expected: the declared link is required, and the automatically injected
+    core_metadata_collection link is still optional.
+
+    Why it matters: the core metadata link is added by the generator, not the
+    author, and Gen3 treats it as optional. Reading `required` per link must not
+    leak the neighbouring link's value onto it.
+    """
+    model, template = build("""
+        version: 0.1.0
+        url: https://example.biocommons.org.au
+        nodes:
+          - name: assay
+            category: biospecimen
+            description: "An assay."
+            properties: []
+          - name: result_file
+            category: data_file
+            description: "A results file."
+            properties: []
+        links:
+          - parent: project
+            multiplicity: one_to_many
+            child: assay
+          - parent: assay
+            multiplicity: one_to_many
+            child: result_file
+            required: true
+    """)
+
+    schema = populate_template('result_file', model, template)
+
+    assert required_by_name(schema) == {
+        'assays': True,
+        'core_metadata_collections': False,
+    }
+
+
+def test_data_file_node_without_declared_links_still_gets_core_metadata():
+    """
+    Input: a data_file node that declares no links at all.
+
+    Expected: it still receives the core_metadata_collection link.
+
+    Why it matters: this is a regression test for a bug found while adding the
+    feature. The injection was conditional on the node already having links, so
+    a link-less data_file node emitted `links: []` while still receiving the
+    matching core_metadata_collections property — producing a schema that failed
+    this tool's own data_file validation rule. The tool should not be able to
+    generate something its validator rejects.
+    """
+    model, template = build("""
+        version: 0.1.0
+        url: https://example.biocommons.org.au
+        nodes:
+          - name: orphan_file
+            category: data_file
+            description: "A file with no declared parent."
+            properties: []
+        links: []
+    """)
+
+    schema = populate_template('orphan_file', model, template)
+
+    assert required_by_name(schema) == {'core_metadata_collections': False}
+
+
+def test_convert_node_links_falls_back_for_raw_dicts():
+    """
+    Input: raw link dicts with no `required` key, passed straight to
+    convert_node_links with the parameter set to False.
+
+    Expected: both emitted links are `required: false`.
+
+    Why it matters: convert_node_links is a public helper with a `required`
+    parameter that predates this feature. Callers passing hand-built dicts must
+    keep working, so a link's own value wins and the parameter remains the
+    fallback rather than being ignored.
+    """
+    raw = [
+        {'parent': 'subject', 'multiplicity': 'one_to_many', 'child': 'measurement'},
+        {'parent': 'site', 'multiplicity': 'one_to_many', 'child': 'measurement'},
+    ]
+
+    converted = convert_node_links(raw, required=False)
+
+    assert [link['required'] for link in converted] == [False, False]
+
+
+def test_declared_required_wins_over_the_parameter():
+    """
+    Input: raw link dicts that declare `required: true`, with the fallback
+    parameter set to False.
+
+    Expected: the declared value wins.
+
+    Why it matters: pins the precedence explicitly. Without it, a future change
+    could reverse the two and every dictionary would silently flip.
+    """
+    raw = [{'parent': 'subject', 'multiplicity': 'one_to_many',
+            'child': 'measurement', 'required': True}]
+
+    converted = convert_node_links(raw, required=False)
+
+    assert converted[0]['required'] is True
+
+
+def test_a_meaningless_required_value_is_rejected():
+    """
+    Input: a link declaring `required: maybe`.
+
+    Expected: validation fails.
+
+    Why it matters: the Gen3 metaschema types this key as a boolean, so a bad
+    value would otherwise surface as a metaschema failure on a generated file,
+    far from the line at fault. Failing during input validation names the link
+    instead. Note that the ordinary boolean spellings YAML and pydantic accept -
+    true/false, yes/no, 1/0 - are coerced rather than rejected, consistent with
+    every other boolean field in the input model.
+    """
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        build(BASE.replace(
+            "        child: measurement\n",
+            "        child: measurement\n        required: maybe\n",
+        ))


### PR DESCRIPTION
Links were declared as a `parent`/`multiplicity`/`child` triple and the generator stamped
`required: true` on every one, so the input language could not describe an optional parent.

That is not a cosmetic gap. Across the four dictionaries built with this tool, **41 of 113 links are
`required: false`**, and the same triple shape appears with both values — in one repository
`subject → site` is required while `subject → demographic_measurements`, an identical `one_to_one`
triple, is not. No rule derived from the triple could produce both, so those values had been
hand-edited into the generated files and were destroyed on every regeneration.

It is also a live blocker: `omix3schemadev` cannot move to input-driven generation until this
exists, because regenerating would silently make eight optional parent relationships mandatory.

## The change

A link may now declare `required`:

```yaml
links:
  - parent: sample
    multiplicity: one_to_many
    child: lipidomics_file          # required by default
  - parent: site
    multiplicity: one_to_many
    child: lipidomics_file
    required: false                 # optional parent
```

It is read **per link**, so where a node has two or three parents each is answered independently
rather than the node getting a single blanket setting. The subgroup wrapper is untouched and still
means "at least one of these", so a node whose links are all optional is not left orphaned.

Default is `true` — what the generator emitted before — so the change is purely additive.

## Also fixed

A `data_file` node with no declared links received no `core_metadata_collection` link while still
receiving the matching property, producing a schema that failed this tool's own
`data_file_link_core_metadata` rule. The tool should not be able to generate something its validator
rejects. No dictionary in the fleet has such a node, so this is inert for existing consumers.

## Verification

**Proof that it is additive:** bpsych, omix3 and acdc were regenerated from their real inputs under
3.0.1 and under this build. All three are **byte-identical** — 19, 31 and 32 files respectively.

`tests/test_link_required.py` adds nine tests: the default, an optional link, per-link values across
a three-link subgroup, the flat single-link path, the injected core-metadata link staying optional,
precedence between a declared value and the fallback parameter, rejection of a meaningless value,
and a regression test for the link-less `data_file` bug. 173 tests pass on Python 3.9–3.12.

Hands-on: declared a mixed subgroup by hand, confirmed it generates `true`/`false`/`false` in the
right places and that `validate` still exits 0.

## Documentation

Detail goes in [`docs/gen3_data_modelling/links.md`](docs/gen3_data_modelling/links.md) — a new
section on declaring links from the `input_yaml`, the multi-parent case, a table distinguishing the
two levels of `required`, and the honest caveat that subgroup `exclusive`/`required` are still not
settable and that links to `program`/`project`/`core_metadata_collection` are discarded.
`first_dictionary.md` gets a short §4.3 with one example. **The quickstart is deliberately
untouched** — it does not discuss links and stays that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)